### PR TITLE
feat(next-sdk): 解耦遮罩呼吸灯与鼠标图标，非操作类动作时仅显示呼吸灯，操作类动作同时显示两者

### DIFF
--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -89,7 +89,6 @@
         :systemPrompt="systemPrompt"
         :promptItems="ecommercePromptItems"
         :pillItems="ecommercePillItems"
-        @chat-stream-finish="handleChatStreamFinish"
       />
     </div>
   </div>
@@ -239,10 +238,6 @@ const mcpServers: Record<string, McpServerConfig> = {
 }
 
 const menuItems = ref<any[]>([])
-
-const handleChatStreamFinish = () => {
-  window.dispatchEvent(new CustomEvent('page-agent-chat-end'))
-}
 
 onMounted(async () => {
   // 本地 MCP Server 启动：失败则直接抛出（核心功能）

--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -89,6 +89,7 @@
         :systemPrompt="systemPrompt"
         :promptItems="ecommercePromptItems"
         :pillItems="ecommercePillItems"
+        @chat-stream-finish="handleChatStreamFinish"
       />
     </div>
   </div>
@@ -238,6 +239,10 @@ const mcpServers: Record<string, McpServerConfig> = {
 }
 
 const menuItems = ref<any[]>([])
+
+const handleChatStreamFinish = () => {
+  window.dispatchEvent(new CustomEvent('page-agent-chat-end'))
+}
 
 onMounted(async () => {
   // 本地 MCP Server 启动：失败则直接抛出（核心功能）

--- a/packages/doc-ai/src/App.vue
+++ b/packages/doc-ai/src/App.vue
@@ -89,6 +89,7 @@
         :systemPrompt="systemPrompt"
         :promptItems="ecommercePromptItems"
         :pillItems="ecommercePillItems"
+        @chat-stream-finish="onChatStreamFinish"
       />
     </div>
   </div>
@@ -238,6 +239,10 @@ const mcpServers: Record<string, McpServerConfig> = {
 }
 
 const menuItems = ref<any[]>([])
+
+const onChatStreamFinish = () => {
+  window.dispatchEvent(new CustomEvent('page-agent-chat-end'))
+}
 
 onMounted(async () => {
   // 本地 MCP Server 启动：失败则直接抛出（核心功能）

--- a/packages/doc-ai/src/main.ts
+++ b/packages/doc-ai/src/main.ts
@@ -2,12 +2,11 @@ import { createApp } from 'vue'
 import router from './router'
 import App from './App.vue'
 import './style.css'
-import { initializeBuiltinWebMCP, registerPageAgentTool } from '@opentiny/next-sdk'
+import { registerPageAgentTool } from '@opentiny/next-sdk'
 import { enableInspectAssist } from '@opentiny/next-sdk/dev'
 
-initializeBuiltinWebMCP()
 // 单页应用工具注册一次即可
-registerPageAgentTool()
+registerPageAgentTool({ removeMaskAfterToolCall: false })
 // 开发态启用元素检视，生产环境不自动展示检视浮钮
 if (import.meta.env.DEV) {
   enableInspectAssist({ brandLabel: 'Inspect' })

--- a/packages/doc-ai/src/main.ts
+++ b/packages/doc-ai/src/main.ts
@@ -7,7 +7,7 @@ import { enableInspectAssist } from '@opentiny/next-sdk/dev'
 
 initializeBuiltinWebMCP()
 // 单页应用工具注册一次即可
-registerPageAgentTool({ removeMaskAfterToolCall: false })
+registerPageAgentTool()
 // 开发态启用元素检视，生产环境不自动展示检视浮钮
 if (import.meta.env.DEV) {
   enableInspectAssist({ brandLabel: 'Inspect' })

--- a/packages/doc-ai/src/main.ts
+++ b/packages/doc-ai/src/main.ts
@@ -7,7 +7,7 @@ import { enableInspectAssist } from '@opentiny/next-sdk/dev'
 
 initializeBuiltinWebMCP()
 // 单页应用工具注册一次即可
-registerPageAgentTool()
+registerPageAgentTool({ removeMaskAfterToolCall: false })
 // 开发态启用元素检视，生产环境不自动展示检视浮钮
 if (import.meta.env.DEV) {
   enableInspectAssist({ brandLabel: 'Inspect' })

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.6",
+  "version": "0.4.7",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -225,22 +225,35 @@ export class SimulatorMask extends EventTarget {
     this.#cursor.classList.add('clicking')
   }
 
-  show() {
-    if (this.shown || this.#disposed) return
+  show(options?: { showCursor?: boolean }) {
+    if (this.#disposed) return
+
+    // 根据 showCursor 动态控制鼠标图标显隐（默认 true）
+    const showCursor = options?.showCursor ?? true
+    const wasHidden = this.#cursor.style.display === 'none'
+
+    if (showCursor) {
+      this.#cursor.style.display = ''
+      // 遮罩首次开启或 cursor 刚从隐藏切为显示时，重置初始坐标到视口中心
+      if (!this.shown || wasHidden) {
+        this.#currentCursorX = window.innerWidth / 2
+        this.#currentCursorY = window.innerHeight / 2
+        this.#targetCursorX = this.#currentCursorX
+        this.#targetCursorY = this.#currentCursorY
+        this.#cursor.style.left = `${this.#currentCursorX}px`
+        this.#cursor.style.top = `${this.#currentCursorY}px`
+      }
+    } else {
+      this.#cursor.style.display = 'none'
+    }
+
+    if (this.shown) return
 
     this.shown = true
     this.motion?.start()
     this.motion?.fadeIn()
 
     this.wrapper.classList.add('visible')
-
-    // Initialize cursor position
-    this.#currentCursorX = window.innerWidth / 2
-    this.#currentCursorY = window.innerHeight / 2
-    this.#targetCursorX = this.#currentCursorX
-    this.#targetCursorY = this.#currentCursorY
-    this.#cursor.style.left = `${this.#currentCursorX}px`
-    this.#cursor.style.top = `${this.#currentCursorY}px`
   }
 
   hide() {
@@ -251,6 +264,8 @@ export class SimulatorMask extends EventTarget {
     this.motion?.pause()
 
     this.#cursor.classList.remove('clicking')
+    // 恢复 cursor 显示状态，为下次 show 做准备
+    this.#cursor.style.display = ''
 
     setTimeout(() => {
       this.wrapper.classList.remove('visible')

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -250,10 +250,15 @@ export class SimulatorMask extends EventTarget {
     if (this.shown) return
 
     this.shown = true
-    this.motion?.start()
-    this.motion?.fadeIn()
-
     this.wrapper.classList.add('visible')
+    
+    // 强制触发重排，确保 Canvas 容器有尺寸后再启动 WebGL 渲染
+    void this.wrapper.offsetHeight
+
+    requestAnimationFrame(() => {
+      this.motion?.start()
+      this.motion?.fadeIn()
+    })
   }
 
   hide() {
@@ -264,8 +269,8 @@ export class SimulatorMask extends EventTarget {
     this.motion?.pause()
 
     this.#cursor.classList.remove('clicking')
-    // 恢复 cursor 显示状态，为下次 show 做准备
-    this.#cursor.style.display = ''
+    // 隐藏 cursor，避免在 800ms 的呼吸灯 fadeOut 动画期间出现不符合预期的光标
+    this.#cursor.style.display = 'none'
 
     setTimeout(() => {
       this.wrapper.classList.remove('visible')

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -80,6 +80,7 @@ export class SimulatorMask extends EventTarget {
   motion: Motion | null = null
 
   #disposed = false
+  #rafId?: number
 
   #cursor = document.createElement('div')
 
@@ -255,13 +256,19 @@ export class SimulatorMask extends EventTarget {
     // 强制触发重排，确保 Canvas 容器有尺寸后再启动 WebGL 渲染
     void this.wrapper.offsetHeight
 
-    requestAnimationFrame(() => {
+    this.#rafId = requestAnimationFrame(() => {
+      this.#rafId = undefined
+      if (!this.shown || this.#disposed) return
       this.motion?.start()
       this.motion?.fadeIn()
     })
   }
 
   hide() {
+    if (this.#rafId !== undefined) {
+      cancelAnimationFrame(this.#rafId)
+      this.#rafId = undefined
+    }
     if (!this.shown || this.#disposed) return
 
     this.shown = false
@@ -278,6 +285,10 @@ export class SimulatorMask extends EventTarget {
   }
 
   dispose() {
+    if (this.#rafId !== undefined) {
+      cancelAnimationFrame(this.#rafId)
+      this.#rafId = undefined
+    }
     this.#disposed = true
     this.motion?.dispose()
     this.wrapper.remove()

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -160,42 +160,42 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
         case 'browserState':
           simulatorMask.show({ showCursor: false })
           ret = await handleBrowserState(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'executeJavascript':
           simulatorMask.show({ showCursor: false })
           ret = await handleExecuteJavascript(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'searchTree':
           simulatorMask.show({ showCursor: false })
           ret = await handleSearchTree(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         // ─── 滚动类：仅呼吸灯，无静止鼠标图标 ───────────────────────────────
         case 'scroll':
           simulatorMask.show({ showCursor: false })
           ret = await handleScroll(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         // ─── 精准操作类：呼吸灯 + 鼠标图标 ─────────────────────────────────
         case 'click':
           simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleClick(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'fill':
           simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleFill(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'select':
           simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleSelect(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'hover': {
           simulatorMask.show({ showCursor: true })
@@ -209,7 +209,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
             )
           }
           ret = await handleHover(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         }
         default:
@@ -228,7 +228,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
           `${actionNames[args.action as keyof typeof actionNames]}执行异常: ${error instanceof Error ? error.message : String(error)}`
         )
       }
-      options.removeMaskAfterToolCall && (await pageController.hideMask())
+      getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
       throw error
     } finally {
       simulatorMask.removeBorderElement()

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -156,40 +156,52 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       let ret: { content: Array<{ type: 'text'; text: string }> }
 
       switch (args.action) {
+        // ─── 感知/脚本类：仅呼吸灯，无鼠标图标 ──────────────────────────────
         case 'browserState':
+          simulatorMask.show({ showCursor: false })
           ret = await handleBrowserState(args, actionContext)
+          options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
+        case 'executeJavascript':
+          simulatorMask.show({ showCursor: false })
+          ret = await handleExecuteJavascript(args, actionContext)
+          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          break
+        case 'searchTree':
+          simulatorMask.show({ showCursor: false })
+          ret = await handleSearchTree(args, actionContext)
+          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          break
+        // ─── 滚动类：仅呼吸灯，无静止鼠标图标 ───────────────────────────────
+        case 'scroll':
+          simulatorMask.show({ showCursor: false })
+          ret = await handleScroll(args, actionContext)
+          options.removeMaskAfterToolCall && (await pageController.hideMask())
+          break
+        // ─── 精准操作类：呼吸灯 + 鼠标图标 ─────────────────────────────────
         case 'click':
-          await pageController.showMask()
+          simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleClick(args, actionContext)
           options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'fill':
-          await pageController.showMask()
+          simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleFill(args, actionContext)
           options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'select':
-          await pageController.showMask()
+          simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
           ret = await handleSelect(args, actionContext)
           options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
-        case 'scroll':
-          await pageController.showMask()
-          ret = await handleScroll(args, actionContext)
-          options.removeMaskAfterToolCall && (await pageController.hideMask())
-          break
-        case 'executeJavascript':
-          ret = await handleExecuteJavascript(args, actionContext)
-          break
-        case 'searchTree':
-          ret = await handleSearchTree(args, actionContext)
-          break
         case 'hover':
+          simulatorMask.show({ showCursor: true })
+          borderTargetElement(args.index)
           ret = await handleHover(args, actionContext)
+          options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
         default:
           ret = { content: [{ type: 'text' as const, text: `未知操作: ${args.action}` }] }
@@ -199,7 +211,8 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       const actionNames = {
         click: '点击',
         fill: '填写',
-        select: '选择'
+        select: '选择',
+        hover: '悬浮'
       } as const
       if (args.action in actionNames) {
         return actionError(

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -197,12 +197,21 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
           ret = await handleSelect(args, actionContext)
           options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
-        case 'hover':
+        case 'hover': {
           simulatorMask.show({ showCursor: true })
           borderTargetElement(args.index)
+          const el = args.index !== undefined ? currentRefMap.get(args.index) : undefined
+          if (el) {
+            const rect = el.getBoundingClientRect()
+            simulatorMask.setCursorPosition(
+              rect.left + rect.width / 2,
+              rect.top + rect.height / 2
+            )
+          }
           ret = await handleHover(args, actionContext)
           options.removeMaskAfterToolCall && (await pageController.hideMask())
           break
+        }
         default:
           ret = { content: [{ type: 'text' as const, text: `未知操作: ${args.action}` }] }
       }

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/design.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/design.md
@@ -55,25 +55,31 @@ flowchart TD
 
 ```typescript
 show(options?: { showCursor?: boolean }) {
-  if (this.shown || this.#disposed) return
+  if (this.#disposed) return
+
+  const showCursor = options?.showCursor ?? true
+  const wasHidden = this.#cursor.style.display === 'none'
+
+  if (showCursor) {
+    this.#cursor.style.display = ''  // 恢复默认显示
+    // 遮罩首次开启或 cursor 刚从隐藏切为显示时，重置到视口中心
+    if (!this.shown || wasHidden) {
+      this.#currentCursorX = window.innerWidth / 2
+      this.#currentCursorY = window.innerHeight / 2
+      this.#targetCursorX = this.#currentCursorX
+      this.#targetCursorY = this.#currentCursorY
+      this.#cursor.style.left = `${this.#currentCursorX}px`
+      this.#cursor.style.top = `${this.#currentCursorY}px`
+    }
+  } else {
+    this.#cursor.style.display = 'none'
+  }
+
+  if (this.shown) return
   this.shown = true
   this.motion?.start()
   this.motion?.fadeIn()
   this.wrapper.classList.add('visible')
-
-  const showCursor = options?.showCursor ?? true
-  if (showCursor) {
-    this.#cursor.style.display = ''  // 恢复默认显示
-    // 重置到视口中心
-    this.#currentCursorX = window.innerWidth / 2
-    this.#currentCursorY = window.innerHeight / 2
-    this.#targetCursorX = this.#currentCursorX
-    this.#targetCursorY = this.#currentCursorY
-    this.#cursor.style.left = `${this.#currentCursorX}px`
-    this.#cursor.style.top = `${this.#currentCursorY}px`
-  } else {
-    this.#cursor.style.display = 'none'
-  }
 }
 ```
 

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/design.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/design.md
@@ -1,0 +1,129 @@
+# Design：遮罩效果拆分 —— 呼吸灯与鼠标图标分层控制
+
+## 方案概述
+
+在 `SimulatorMask.show()` 上增加可选参数 `{ showCursor?: boolean }`，调用时决定是否显示鼠标图标元素（`#cursor`）。不修改 `@page-agent/page-controller` 的外部包签名，而是在 `page-agent-tool.ts` 的调度层直接调用 `simulatorMask.show()` 来控制。
+
+由于 `pageController.showMask()` 内部会委托 `mask.show()`，但不支持传参，我们改为在 `switch` 各分支直接调用 `simulatorMask.show({ showCursor })` 并跳过 `pageController.showMask()`（后者本就是对 mask.show 的转发）。
+
+## 涉及模块 / 文件
+
+- `packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts`：改造 `show()` 方法
+- `packages/next-sdk/page-tools/page-agent-tool.ts`：调度层按 action 分类调用
+- `packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts`：更新 mock + 补测试
+- `packages/next-sdk/test/page-tools/page-agent-tool.test.ts`：补 showCursor 相关断言
+
+## 核心数据结构 / 类型定义
+
+```typescript
+// SimulatorMask.ts
+interface ShowOptions {
+  /** 是否显示 AI 鼠标图标，默认 true */
+  showCursor?: boolean
+}
+
+class SimulatorMask {
+  show(options?: ShowOptions): void
+}
+```
+
+## API / 行为变更
+
+| 符号或行为 | 变更类型 | 说明 |
+|---|---|---|
+| `SimulatorMask.show()` | 修改 | 新增可选 `options.showCursor`，默认 `true` 保持向后兼容 |
+| `page-agent-tool` `hover` action | 修改 | 补调 `showMask`、`borderTargetElement`、`hideMask` |
+| `page-agent-tool` `scroll` action | 修改 | 改为 `showCursor: false`，仅呼吸灯 |
+| `page-agent-tool` `browserState` / `searchTree` / `executeJavascript` | 新增 | 补调 `showMask({ showCursor: false })`，呼吸灯提示 AI 在工作 |
+
+## 数据流 / 时序
+
+```mermaid
+flowchart TD
+  A[executePageAgentTool] -->|action| B{分类}
+  B -->|感知/脚本/滚动| C[simulatorMask.show 仅呼吸灯]
+  B -->|精准操作| D[simulatorMask.show 呼吸灯+鼠标]
+  D --> E[borderTargetElement]
+  C --> F[handler]
+  E --> F
+  F --> G[hideMask?]
+```
+
+## 实现细节
+
+### SimulatorMask.show() 改造
+
+```typescript
+show(options?: { showCursor?: boolean }) {
+  if (this.shown || this.#disposed) return
+  this.shown = true
+  this.motion?.start()
+  this.motion?.fadeIn()
+  this.wrapper.classList.add('visible')
+
+  const showCursor = options?.showCursor ?? true
+  if (showCursor) {
+    this.#cursor.style.display = ''  // 恢复默认显示
+    // 重置到视口中心
+    this.#currentCursorX = window.innerWidth / 2
+    this.#currentCursorY = window.innerHeight / 2
+    this.#targetCursorX = this.#currentCursorX
+    this.#targetCursorY = this.#currentCursorY
+    this.#cursor.style.left = `${this.#currentCursorX}px`
+    this.#cursor.style.top = `${this.#currentCursorY}px`
+  } else {
+    this.#cursor.style.display = 'none'
+  }
+}
+```
+
+### hide() 改造（重置 cursor 显示状态）
+
+```typescript
+hide() {
+  if (!this.shown || this.#disposed) return
+  this.shown = false
+  this.motion?.fadeOut()
+  this.motion?.pause()
+  this.#cursor.classList.remove('clicking')
+  // 恢复 cursor 显示，为下次 show 做准备
+  this.#cursor.style.display = ''
+  setTimeout(() => {
+    this.wrapper.classList.remove('visible')
+  }, 800)
+}
+```
+
+### page-agent-tool.ts 调度层
+
+```typescript
+// 精准操作类：呼吸灯 + 鼠标
+case 'click':
+case 'fill':
+case 'select':
+case 'hover':
+  simulatorMask.show({ showCursor: true })  // 直接调用，绕过 pageController
+  borderTargetElement(args.index)
+  ret = await handler(args, actionContext)
+  options.removeMaskAfterToolCall && (await pageController.hideMask())
+  break
+
+// 感知/脚本/滚动类：仅呼吸灯
+case 'browserState':
+case 'searchTree':
+case 'executeJavascript':
+case 'scroll':
+  simulatorMask.show({ showCursor: false })
+  ret = await handler(args, actionContext)
+  options.removeMaskAfterToolCall && (await pageController.hideMask())
+  break
+```
+
+## 风险与兼容
+
+- `SimulatorMask.show()` 默认值 `showCursor: true`，向后兼容现有 `handle.showMask()` 调用（内部转发到 `pageController.showMask()` → `mask.show()`，无参数，走默认值）。
+- `searchTree` 和 `executeJavascript` 的 handler 内部有 `ctx.pageController.hideMask()` 调用，与调度层的 `removeMaskAfterToolCall` 控制不冲突（`hideMask` 幂等）。
+
+## 备选方案
+
+- 为 `SimulatorMask` 单独增加 `showCursorOnly()` 方法：语义更明确，但方法数增加；不如参数化简洁。

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/requirements.md
@@ -48,5 +48,6 @@
 ## 完成定义
 
 - [x] `requirements.md` / `design.md` / `tasks.md` 已齐
-- [ ] 对应单元测试已在 `tasks.md` 列出并实现
-- [ ] `pnpm test` 通过
+- [x] 对应单元测试已在 `tasks.md` 列出并实现
+- [x] `pnpm test` (201 tests passed)
+- [x] `pnpm -F @opentiny/next-sdk build` 通过

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/requirements.md
@@ -1,0 +1,52 @@
+# Spec：遮罩效果拆分 —— 呼吸灯与鼠标图标分层控制
+
+## 元信息
+
+- 状态：开发中
+- 主责包：`packages/next-sdk`
+- 关联 Issue：无（用户口头需求）
+
+## 背景
+
+`SimulatorMask` 中的呼吸灯动效（ai-motion 炫彩边框）与鼠标图标（AI Cursor 箭头）目前总是绑定在一起，`show()` 时两者同时出现。但不同 action 对视觉反馈的需求不同：
+
+- **感知/脚本类 action**（`browserState`、`searchTree`、`executeJavascript`）：Agent 在"读取"或"执行"，无需移动鼠标图标，只需呼吸灯提示 AI 在工作。
+- **滚动类 action**（`scroll`）：滚动操作无具体目标坐标，显示静止鼠标图标无意义，仅呼吸灯即可。
+- **精准操作类 action**（`click`、`fill`、`select`、`hover`）：需完整展示呼吸灯 + 鼠标图标（含指针移动和点击波纹），让用户观察 AI 的具体操作位置。
+
+当前还有一个缺漏：`hover` 操作完全没有调用 `showMask()`，与 `click`/`fill`/`select` 不一致。
+
+## 目标用户 / 场景
+
+- 使用 `registerPageAgentTool()` 接入 page-agent 的开发者和最终用户
+- 观察 AI 自动操作页面过程的用户
+
+## 范围
+
+### In Scope
+
+- `SimulatorMask.show()` 新增 `showCursor` 选项，可独立隐藏鼠标图标
+- `SimulatorMask` 新增 `showCursorOnly()` / 改造为 `showBreathingOnly()` 便捷方法（或直接由调度层控制）
+- `page-agent-tool.ts` 调度层按 action 分两类调用遮罩
+- `hover` 补齐 `showMask` + 目标元素 border 高亮
+- 对应单元测试
+
+### Out of Scope
+
+- 修改 `@page-agent/page-controller` 的 `showMask`/`hideMask` 签名（外部包）
+- 修改 `a11y-tree`、序列化或工具协议
+
+## 用户故事与验收标准
+
+1. 作为用户，当 Agent 执行 `browserState`/`searchTree`/`executeJavascript` 时，我只看到呼吸灯动效，不出现鼠标图标
+   - 验收：`SimulatorMask.show({ showCursor: false })` 不渲染 cursor 元素
+2. 作为用户，当 Agent 执行 `scroll` 时，我只看到呼吸灯，不出现静止鼠标图标
+   - 验收：`scroll` action 调用 `simulatorMask.show({ showCursor: false })`
+3. 作为用户，当 Agent 执行 `click`/`fill`/`select`/`hover` 时，同时看到呼吸灯和鼠标图标移动到目标元素
+   - 验收：`hover` 补调 `showMask()`，`borderTargetElement` 对 hover 也生效
+
+## 完成定义
+
+- [x] `requirements.md` / `design.md` / `tasks.md` 已齐
+- [ ] 对应单元测试已在 `tasks.md` 列出并实现
+- [ ] `pnpm test` 通过

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/tasks.md
@@ -1,0 +1,30 @@
+# Tasks：遮罩效果拆分 —— 呼吸灯与鼠标图标分层控制
+
+每个任务应可独立验收；涉及行为变更的任务 **必须** 含测试子项。
+
+## 任务列表
+
+- [x] Task 1：改造 `SimulatorMask.show()` 支持 `showCursor` 选项
+  - 输入：`packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts`
+  - 产物：`show(options?: { showCursor?: boolean })` 新签名，`hide()` 重置 cursor 显示状态
+  - [x] 测试：`packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts` 中新增断言覆盖
+
+- [x] Task 2：改造 `page-agent-tool.ts` 调度层，按 action 分两类控制遮罩
+  - 输入：依赖 Task 1 完成
+  - 产物：
+    - `click`/`fill`/`select`/`hover`：`simulatorMask.show({ showCursor: true })` + `borderTargetElement`
+    - `browserState`/`searchTree`/`executeJavascript`/`scroll`：`simulatorMask.show({ showCursor: false })`
+  - [x] 测试：更新 `packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts`，新增遮罩模式 8 条用例
+
+- [x] Task 3：验收命令通过 — 198 tests passed
+  - 命令：`pnpm -F @opentiny/next-sdk test`
+
+## 依赖顺序
+
+1 → 2 → 3
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+```

--- a/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260810-mask-cursor-split/tasks.md
@@ -16,8 +16,9 @@
     - `browserState`/`searchTree`/`executeJavascript`/`scroll`：`simulatorMask.show({ showCursor: false })`
   - [x] 测试：更新 `packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts`，新增遮罩模式 8 条用例
 
-- [x] Task 3：验收命令通过 — 198 tests passed
-  - 命令：`pnpm -F @opentiny/next-sdk test`
+- [x] Task 3：验收命令通过 — 201 tests passed, build 通关
+  - 命令：`pnpm -F @opentiny/next-sdk test` 
+  - 命令：`pnpm -F @opentiny/next-sdk build`
 
 ## 依赖顺序
 
@@ -27,4 +28,5 @@
 
 ```bash
 pnpm -F @opentiny/next-sdk test
+pnpm -F @opentiny/next-sdk build
 ```

--- a/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
@@ -11,7 +11,14 @@ const { handlerMocks } = vi.hoisted(() => {
   })
   return {
     handlerMocks: {
-      handleBrowserState: vi.fn(async () => marker('browserState')),
+      handleBrowserState: vi.fn(async (_args, context: any) => {
+        const el = document.createElement('div')
+        el.getBoundingClientRect = () => ({ x: 10, y: 20, width: 100, height: 200, top: 20, left: 10, bottom: 220, right: 110, toJSON: () => {} })
+        const map = new Map()
+        map.set(0, el)
+        context?.setRefMap?.(map)
+        return marker('browserState')
+      }),
       handleClick: vi.fn(async () => marker('click')),
       handleFill: vi.fn(async () => marker('fill')),
       handleSelect: vi.fn(async () => marker('select')),
@@ -23,8 +30,8 @@ const { handlerMocks } = vi.hoisted(() => {
   }
 })
 
-// SimulatorMask.show 改为 vi.fn 以支持断言遮罩模式
 const mockSimulatorMaskShow = vi.fn()
+const mockSimulatorMaskSetCursorPosition = vi.fn()
 
 vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
   SimulatorMask: class SimulatorMask {
@@ -33,6 +40,7 @@ vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
     dispose() {}
     borderElement() {}
     removeBorderElement() {}
+    setCursorPosition(x: number, y: number) { mockSimulatorMaskSetCursorPosition(x, y) }
   },
 }))
 
@@ -196,6 +204,7 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
       mock.mockClear()
     }
     mockSimulatorMaskShow.mockClear()
+    mockSimulatorMaskSetCursorPosition.mockClear()
   })
 
   afterAll(() => {
@@ -237,5 +246,18 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
         expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: true })
       }
     )
+
+    it('复现：hover 操作应在调用 handler 前更新鼠标位置到目标元素中心', async () => {
+      // 1. 先发 browserState 构建 refMap
+      await execute(argsFor('browserState'))
+      
+      // 2. 发送 hover
+      await execute(argsFor('hover'))
+      
+      // getBoundingClientRect = { left: 10, top: 20, width: 100, height: 200 }
+      // center x = 10 + 50 = 60
+      // center y = 20 + 100 = 120
+      expect(mockSimulatorMaskSetCursorPosition).toHaveBeenCalledWith(60, 120)
+    })
   })
 })

--- a/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
@@ -250,14 +250,22 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
     it('复现：hover 操作应在调用 handler 前更新鼠标位置到目标元素中心', async () => {
       // 1. 先发 browserState 构建 refMap
       await execute(argsFor('browserState'))
-      
+
+      mockSimulatorMaskSetCursorPosition.mockClear()
+      handlerMocks.handleHover.mockClear()
+
       // 2. 发送 hover
       await execute(argsFor('hover'))
-      
+
       // getBoundingClientRect = { left: 10, top: 20, width: 100, height: 200 }
       // center x = 10 + 50 = 60
       // center y = 20 + 100 = 120
       expect(mockSimulatorMaskSetCursorPosition).toHaveBeenCalledWith(60, 120)
+
+      // 断言调用顺序：setCursorPosition 必须在 handleHover 之前
+      const setCursorOrder = mockSimulatorMaskSetCursorPosition.mock.invocationCallOrder[0]
+      const handleHoverOrder = handlerMocks.handleHover.mock.invocationCallOrder[0]
+      expect(setCursorOrder).toBeLessThan(handleHoverOrder)
     })
   })
 })

--- a/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
@@ -18,13 +18,17 @@ const { handlerMocks } = vi.hoisted(() => {
       handleScroll: vi.fn(async () => marker('scroll')),
       handleExecuteJavascript: vi.fn(async () => marker('executeJavascript')),
       handleSearchTree: vi.fn(async () => marker('searchTree')),
+      handleHover: vi.fn(async () => marker('hover')),
     },
   }
 })
 
+// SimulatorMask.show 改为 vi.fn 以支持断言遮罩模式
+const mockSimulatorMaskShow = vi.fn()
+
 vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
   SimulatorMask: class SimulatorMask {
-    show() {}
+    show(options?: { showCursor?: boolean }) { mockSimulatorMaskShow(options) }
     hide() {}
     dispose() {}
     borderElement() {}
@@ -65,6 +69,9 @@ vi.mock('../../page-tools/handlers/executeJavascript', () => ({
 vi.mock('../../page-tools/handlers/searchTree', () => ({
   handleSearchTree: handlerMocks.handleSearchTree,
 }))
+vi.mock('../../page-tools/handlers/hover', () => ({
+  handleHover: handlerMocks.handleHover,
+}))
 
 import { registerPageAgentTool } from '../../page-tools/page-agent-tool'
 import type { PageAgentToolInput } from '../../page-tools/schema'
@@ -104,6 +111,7 @@ const ACTIONS = [
   'scroll',
   'executeJavascript',
   'searchTree',
+  'hover',
 ] as const
 
 type ActionName = (typeof ACTIONS)[number]
@@ -116,6 +124,7 @@ const handlerByAction: Record<ActionName, keyof typeof handlerMocks> = {
   scroll: 'handleScroll',
   executeJavascript: 'handleExecuteJavascript',
   searchTree: 'handleSearchTree',
+  hover: 'handleHover',
 }
 
 function resetWindowGlobals() {
@@ -166,6 +175,8 @@ function argsFor(action: ActionName): PageAgentToolInput {
       return { action, script: '1+1', contextLines: 2, maxMatches: 20 }
     case 'searchTree':
       return { action, query: 'button', contextLines: 2, maxMatches: 20 }
+    case 'hover':
+      return { action, index: 0, contextLines: 2, maxMatches: 20 }
   }
 }
 
@@ -184,6 +195,7 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
     for (const mock of Object.values(handlerMocks)) {
       mock.mockClear()
     }
+    mockSimulatorMaskShow.mockClear()
   })
 
   afterAll(() => {
@@ -204,5 +216,26 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
         expect(mock, `${key} must not be called for action=${action}`).not.toHaveBeenCalled()
       }
     }
+  })
+
+  describe('遮罩模式：仅呼吸灯 vs 呼吸灯+鼠标图标', () => {
+    const breathingOnlyActions: ActionName[] = ['browserState', 'executeJavascript', 'searchTree', 'scroll']
+    const fullMaskActions: ActionName[] = ['click', 'fill', 'select', 'hover']
+
+    it.each(breathingOnlyActions)(
+      '复现：感知/脚本/滚动类 action=%s 应只展示呼吸灯，不展示鼠标图标（showCursor: false）',
+      async (action) => {
+        await execute(argsFor(action))
+        expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: false })
+      }
+    )
+
+    it.each(fullMaskActions)(
+      '复现：精准操作类 action=%s 应同时展示呼吸灯和鼠标图标（showCursor: true）',
+      async (action) => {
+        await execute(argsFor(action))
+        expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: true })
+      }
+    )
   })
 })

--- a/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
+++ b/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { SimulatorMask } from '../../page-tools/page-agent-mask/SimulatorMask'
+
+describe('SimulatorMask 鼠标指针显隐与连续切换逻辑', () => {
+  let mask: SimulatorMask
+
+  beforeEach(() => {
+    // 模拟 jsdom 环境下的动画与页面宽高
+    vi.spyOn(window, 'innerWidth', 'get').mockReturnValue(1024)
+    vi.spyOn(window, 'innerHeight', 'get').mockReturnValue(768)
+  })
+
+  afterEach(() => {
+    mask?.dispose()
+    vi.restoreAllMocks()
+  })
+
+  it('复现：先执行 browserState(无鼠标) 再执行 click(有鼠标) 时鼠标箭头未出现的 Bug —— 步骤 1. show({ showCursor: false })；步骤 2. 连续 show({ showCursor: true })；期望 #cursor 的 style.display 被恢复为 ""', () => {
+    mask = new SimulatorMask()
+
+    // 1. 模拟执行 browserState: show({ showCursor: false })
+    mask.show({ showCursor: false })
+    expect(mask.shown).toBe(true)
+
+    const cursorEl = mask.wrapper.querySelector('.webmcp-page-agent-cursor') as HTMLElement
+    expect(cursorEl).not.toBeNull()
+    expect(cursorEl.style.display).toBe('none')
+
+    // 2. 遮罩处于 shown=true 状态下，模拟执行 click/fill: show({ showCursor: true })
+    mask.show({ showCursor: true })
+
+    // 期望：cursorEl 的 display 应当恢复为空字符串（即显示鼠标）
+    expect(cursorEl.style.display).toBe('')
+  })
+
+  it('默认为 showCursor: true 时，鼠标样式为 display: ""', () => {
+    mask = new SimulatorMask()
+    mask.show()
+    const cursorEl = mask.wrapper.querySelector('.webmcp-page-agent-cursor') as HTMLElement
+    expect(cursorEl.style.display).toBe('')
+  })
+})

--- a/packages/next-sdk/vitest-order-test.ts
+++ b/packages/next-sdk/vitest-order-test.ts
@@ -1,9 +1,0 @@
-import { test, vi, expect } from 'vitest'
-
-const mock1 = vi.fn()
-const mock2 = vi.fn()
-
-mock1()
-mock2()
-
-console.log(mock1.mock.invocationCallOrder[0], mock2.mock.invocationCallOrder[0])

--- a/packages/next-sdk/vitest-order-test.ts
+++ b/packages/next-sdk/vitest-order-test.ts
@@ -1,0 +1,9 @@
+import { test, vi, expect } from 'vitest'
+
+const mock1 = vi.fn()
+const mock2 = vi.fn()
+
+mock1()
+mock2()
+
+console.log(mock1.mock.invocationCallOrder[0], mock2.mock.invocationCallOrder[0])


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved visual feedback during automated actions by separating the breathing indicator, cursor, and target highlighting.
  * Precise actions show the cursor and target border, while non-visual actions display only the breathing indicator.
  * Hover actions position the cursor at the center of the target.
  * Chat completion now emits an event when streaming ends.

* **Bug Fixes**
  * Improved animation timing and cleanup to prevent flickering or stale overlays.

* **Documentation**
  * Added documentation for the updated mask behavior.

* **Chores**
  * Updated package versions to 0.4.7.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->