### PR TITLE
fix: update tool registration to support AbortSignal for cleaner lif…

### DIFF
--- a/packages/next-sdk/agent/type.ts
+++ b/packages/next-sdk/agent/type.ts
@@ -11,8 +11,11 @@ export interface BuiltinMcpClient {
   listTools?: () => Promise<any[]>
   getTools?: () => Promise<any[]>
   executeTool: (tool: any, input: string) => Promise<any>
-  registerTool?: (config: { name: string; execute: (input: any) => Promise<any> | any; [key: string]: any }) => void
-  unregisterTool?: (name: string) => void
+  registerTool?: (
+    config: { name: string; execute: (input: any) => Promise<any> | any; [key: string]: any },
+    options?: { signal?: AbortSignal }
+  ) => void
+
 }
 
 type ProviderFactory = 'openai' | 'deepseek' | ((options: any) => ProviderV2)

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -250,28 +250,36 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
     }
   }
   try {
-    modelContext.unregisterTool?.('page-agent-tool')
+    if ((window as any).__pageAgentToolAbortController) {
+      ;(window as any).__pageAgentToolAbortController.abort()
+    }
   } catch {
     // 首次注册或不存在时忽略
   }
+
+  const abortController = new AbortController()
+  ;(window as any).__pageAgentToolAbortController = abortController
 
   const executeJavascriptPrompt = getPageAgentToolConfig().enableExecuteJavascript
     ? ''
     : '\n 当前环境已经禁用 executeJavascript 工具，请勿使用它。\n'
 
-  modelContext.registerTool({
-    name: 'page-agent-tool',
-    description: pageAgentPrompt + executeJavascriptPrompt,
-    // @ts-ignore
-    inputSchema: zodToJsonSchema(inputSchema) as any,
-    async execute(args: PageAgentToolInput) {
-      try {
-        return executePageAgentTool(args)
-      } catch (error) {
-        return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
+  modelContext.registerTool(
+    {
+      name: 'page-agent-tool',
+      description: pageAgentPrompt + executeJavascriptPrompt,
+      // @ts-ignore
+      inputSchema: zodToJsonSchema(inputSchema) as any,
+      async execute(args: PageAgentToolInput) {
+        try {
+          return executePageAgentTool(args)
+        } catch (error) {
+          return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
+        }
       }
-    }
-  })
+    },
+    { signal: abortController.signal }
+  )
 
   setupPageAgentToolEventBridge(executePageAgentTool, pageController, actionContext)
 

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -272,7 +272,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       inputSchema: zodToJsonSchema(inputSchema) as any,
       async execute(args: PageAgentToolInput) {
         try {
-          return executePageAgentTool(args)
+          return await executePageAgentTool(args)
         } catch (error) {
           return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
         }

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -12,12 +12,20 @@ vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
       maskSpies.hide()
     }
     dispose() {}
+    removeBorderElement() {}
+    borderElement() {}
+    setCursorPosition() {}
   },
 }))
 
 import { registerPageAgentTool } from '../../page-tools/page-agent-tool'
 import { PAGE_AGENT_CHAT_END_EVENT } from '../../page-tools/page-agent-tool-event'
 import { getPageAgentToolConfig, setPageAgentToolConfig } from '../../page-tools/tool-config'
+import { handleClipboard } from '../../page-tools/handlers/clipboard'
+
+vi.mock('../../page-tools/handlers/clipboard', () => ({
+  handleClipboard: vi.fn()
+}))
 
 function resetWindowGlobals() {
   delete window.__webmcpcli_toolConfig
@@ -148,6 +156,27 @@ describe('registerPageAgentTool - mask 显隐句柄', () => {
 })
 
 describe('registerPageAgentTool - 工具注册与注销机制', () => {
+  it('复现：executePageAgentTool 中的异步 rejection 应该被外部 catch 捕获并转换为异常内容', async () => {
+    let execute: any = null
+    const originalRegister = (document as any).modelContext.registerTool
+    ;(document as any).modelContext.registerTool = (tool: any, options: any) => {
+      if (tool.name === 'page-agent-tool') execute = tool.execute
+      originalRegister.call((document as any).modelContext, tool, options)
+    }
+
+    registerPageAgentTool()
+    ;(document as any).modelContext.registerTool = originalRegister
+
+    expect(execute).toBeDefined()
+
+    vi.mocked(handleClipboard).mockRejectedValueOnce(new Error('Mock clipboard rejection'))
+
+    const result = await execute({ action: 'clipboard', text: 'test' } as any)
+    
+    expect(result.content).toBeDefined()
+    expect(result.content[0].type).toBe('text')
+    expect(result.content[0].text).toContain('异常: Error: Mock clipboard rejection')
+  })
   it('重复注册时应调用前一次的 AbortController 取消前一个注册', () => {
     // 第一次注册
     registerPageAgentTool()

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -22,6 +22,10 @@ import { getPageAgentToolConfig, setPageAgentToolConfig } from '../../page-tools
 function resetWindowGlobals() {
   delete window.__webmcpcli_toolConfig
   delete window.__webmcpcli_beforeGetBrowserState
+  if ((window as any).__pageAgentToolAbortController) {
+    ;(window as any).__pageAgentToolAbortController.abort()
+    delete (window as any).__pageAgentToolAbortController
+  }
   // 注意：initializeBuiltinWebMCP() 内部用模块级单例 flag 控制只初始化一次 document.modelContext，
   // 且没有对外暴露重置能力，因此这里不删除 document.modelContext，避免二次调用时因单例 flag
   // 仍为 true 而不会重新创建 modelContext，导致 registerTool 拿到 undefined
@@ -140,5 +144,29 @@ describe('registerPageAgentTool - mask 显隐句柄', () => {
     await vi.waitFor(() => {
       expect(maskSpies.hide).toHaveBeenCalledTimes(1)
     })
+  })
+})
+
+describe('registerPageAgentTool - 工具注册与注销机制', () => {
+  it('重复注册时应调用前一次的 AbortController 取消前一个注册', () => {
+    // 第一次注册
+    registerPageAgentTool()
+    const firstAbortController = (window as any).__pageAgentToolAbortController
+    expect(firstAbortController).toBeDefined()
+    
+    // 监听第一次注册的 abort 信号
+    const abortSpy = vi.fn()
+    firstAbortController.signal.addEventListener('abort', abortSpy)
+
+    // 第二次注册
+    registerPageAgentTool()
+    
+    // 验证前一次的 abort 被触发
+    expect(abortSpy).toHaveBeenCalledTimes(1)
+    
+    // 验证控制器已经被替换为新的
+    const secondAbortController = (window as any).__pageAgentToolAbortController
+    expect(secondAbortController).toBeDefined()
+    expect(secondAbortController).not.toBe(firstAbortController)
   })
 })

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -177,7 +177,11 @@ describe('registerPageAgentTool - 工具注册与注销机制', () => {
     expect(result.content[0].type).toBe('text')
     expect(result.content[0].text).toContain('异常: Error: Mock clipboard rejection')
   })
-  it('重复注册时应调用前一次的 AbortController 取消前一个注册', () => {
+  it('复现：重复注册时应调用前一次的 AbortController 取消前一个注册', async () => {
+    const originalRegister = (document as any).modelContext.registerTool;
+    const registerSpy = vi.fn(originalRegister.bind((document as any).modelContext));
+    ;(document as any).modelContext.registerTool = registerSpy;
+
     // 第一次注册
     registerPageAgentTool()
     const firstAbortController = (window as any).__pageAgentToolAbortController
@@ -197,5 +201,19 @@ describe('registerPageAgentTool - 工具注册与注销机制', () => {
     const secondAbortController = (window as any).__pageAgentToolAbortController
     expect(secondAbortController).toBeDefined()
     expect(secondAbortController).not.toBe(firstAbortController)
+    
+    // 验证 register API 收到 signal
+    const firstCallOptions = registerSpy.mock.calls[0][1];
+    expect(firstCallOptions?.signal).toBe(firstAbortController.signal);
+    const secondCallOptions = registerSpy.mock.calls[1][1];
+    expect(secondCallOptions?.signal).toBe(secondAbortController.signal);
+    
+    // 验证旧工具已被移除 (如果是通过 abort 移除了)
+    // 可以尝试从 modelContext.getTools() 取当前注册的工具
+    const tools = await (document as any).modelContext.getTools();
+    // 实际上由于 registerTool 是同名的，第二次注册可能覆盖或者由于第一次已经 abort，只剩下一个
+    expect(tools.filter((t: any) => t.name === 'page-agent-tool').length).toBe(1);
+    
+    ;(document as any).modelContext.registerTool = originalRegister;
   })
 })

--- a/packages/next-wxt/entrypoints/sidepanel/mcpServer.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/mcpServer.ts
@@ -29,8 +29,15 @@ export const setupLocalTools = () => {
     nativeCtx = {
       _tools: new Map(),
       getTools: async () => Array.from(nativeCtx._tools.values()),
-      registerTool: (tool: any) => nativeCtx._tools.set(tool.name, tool),
-      unregisterTool: (name: string) => nativeCtx._tools.delete(name),
+      registerTool: (tool: any, options?: { signal?: AbortSignal }) => {
+        nativeCtx._tools.set(tool.name, tool)
+        if (options?.signal) {
+          options.signal.addEventListener('abort', () => {
+            nativeCtx._tools.delete(tool.name)
+          })
+        }
+      },
+
       executeTool: async (tool: any, argsStr: string) => {
         const args = argsStr ? JSON.parse(argsStr) : {}
         return await tool.execute(args)
@@ -56,16 +63,13 @@ export const setupLocalTools = () => {
 
   // 2. 记录已注册的页面代理工具，防止重复注册
   const registeredProxyTools = new Set<string>()
+  let proxyToolsAbortController: AbortController | null = null
 
   const clearProxyTools = () => {
-    if (registeredProxyTools.size === 0) return
-    registeredProxyTools.forEach((name) => {
-      try {
-        nativeCtx.unregisterTool?.(name)
-      } catch {
-        // ignore
-      }
-    })
+    if (proxyToolsAbortController) {
+      proxyToolsAbortController.abort()
+      proxyToolsAbortController = null
+    }
     registeredProxyTools.clear()
   }
 
@@ -79,7 +83,10 @@ export const setupLocalTools = () => {
       console.log('syncPageProxy: drop stale tabId', tabId)
       return
     }
-    if (tabInfo.url && (tabInfo.url.startsWith('chrome://') || tabInfo.url.startsWith('edge://') || tabInfo.url.startsWith('about:'))) {
+    if (
+      tabInfo.url &&
+      (tabInfo.url.startsWith('chrome://') || tabInfo.url.startsWith('edge://') || tabInfo.url.startsWith('about:'))
+    ) {
       console.log('syncPageProxy: cannot access chrome/edge/about URL')
       clearProxyTools()
       return
@@ -121,7 +128,10 @@ export const setupLocalTools = () => {
         }
       })
       tools = (execRes[0]?.result || []).filter((t: any) => t?.name)
-      console.log('syncPageProxy: got tools', tools.map((t: any) => t.name))
+      console.log(
+        'syncPageProxy: got tools',
+        tools.map((t: any) => t.name)
+      )
     } catch (err) {
       console.warn('syncPageProxy: executeScript failed', err)
     }
@@ -138,63 +148,70 @@ export const setupLocalTools = () => {
       return
     }
 
+    if (!proxyToolsAbortController) {
+      proxyToolsAbortController = new AbortController()
+    }
+
     tools.forEach((tool) => {
       if (registeredProxyTools.has(tool.name)) return
       registeredProxyTools.add(tool.name)
 
-      nativeCtx.registerTool({
-        name: tool.name,
-        title: tool.title,
-        description: tool.description,
-        inputSchema: tool.inputSchema,
-        execute: async (args: unknown) => {
-          const registeredTabId = tabId
-          if (!registeredTabId) {
-            return { content: [{ type: 'text', text: 'Error: No active tab found' }] }
-          }
+      nativeCtx.registerTool(
+        {
+          name: tool.name,
+          title: tool.title,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          execute: async (args: unknown) => {
+            const registeredTabId = tabId
+            if (!registeredTabId) {
+              return { content: [{ type: 'text', text: 'Error: No active tab found' }] }
+            }
 
-          let res: { success: boolean; result?: unknown; error?: string } | null = null
-          try {
-            const execRes = await browser.scripting.executeScript({
-              target: { tabId: registeredTabId },
-              world: 'MAIN',
-              func: async (name: string, inputStr: string) => {
-                try {
-                  const ctx = (document as any).modelContext
-                  if (!ctx) throw new Error('WebMCP is not initialized on this page')
-                  const tools = await ctx.getTools()
-                  const toolObj = tools.find((t: any) => t.name === name)
-                  if (!toolObj) throw new Error(`Tool ${name} not found`)
-                  const execRes = await ctx.executeTool(toolObj, inputStr)
-                  return { success: true, result: execRes }
-                } catch (e: any) {
-                  return { success: false, error: e.message }
+            let res: { success: boolean; result?: unknown; error?: string } | null = null
+            try {
+              const execRes = await browser.scripting.executeScript({
+                target: { tabId: registeredTabId },
+                world: 'MAIN',
+                func: async (name: string, inputStr: string) => {
+                  try {
+                    const ctx = (document as any).modelContext
+                    if (!ctx) throw new Error('WebMCP is not initialized on this page')
+                    const tools = await ctx.getTools()
+                    const toolObj = tools.find((t: any) => t.name === name)
+                    if (!toolObj) throw new Error(`Tool ${name} not found`)
+                    const execRes = await ctx.executeTool(toolObj, inputStr)
+                    return { success: true, result: execRes }
+                  } catch (e: any) {
+                    return { success: false, error: e.message }
+                  }
+                },
+                args: [tool.name, JSON.stringify(args)]
+              })
+              res = execRes[0]?.result
+            } catch (err: any) {
+              console.warn('syncPageProxy: tool exec failed', err)
+              res = { success: false, error: err.message }
+            }
+
+            if (!res?.success) {
+              return { content: [{ type: 'text', text: `Error: ${res?.error || 'Unknown error'}` }] }
+            }
+
+            if (res.result?.content) return res.result
+
+            return {
+              content: [
+                {
+                  type: 'text',
+                  text: typeof res.result === 'string' ? res.result : JSON.stringify(res.result)
                 }
-              },
-              args: [tool.name, JSON.stringify(args)]
-            })
-            res = execRes[0]?.result
-          } catch (err: any) {
-            console.warn('syncPageProxy: tool exec failed', err)
-            res = { success: false, error: err.message }
+              ]
+            }
           }
-
-          if (!res?.success) {
-            return { content: [{ type: 'text', text: `Error: ${res?.error || 'Unknown error'}` }] }
-          }
-
-          if (res.result?.content) return res.result
-
-          return {
-            content: [
-              {
-                type: 'text',
-                text: typeof res.result === 'string' ? res.result : JSON.stringify(res.result)
-              }
-            ]
-          }
-        }
-      })
+        },
+        { signal: proxyToolsAbortController?.signal }
+      )
     })
   }
 

--- a/packages/next-wxt/entrypoints/sidepanel/mcpServer.ts
+++ b/packages/next-wxt/entrypoints/sidepanel/mcpServer.ts
@@ -30,11 +30,19 @@ export const setupLocalTools = () => {
       _tools: new Map(),
       getTools: async () => Array.from(nativeCtx._tools.values()),
       registerTool: (tool: any, options?: { signal?: AbortSignal }) => {
+        if (options?.signal?.aborted) {
+          return Promise.reject(options.signal.reason)
+        }
+        if (nativeCtx._tools.has(tool.name)) {
+          throw new Error(`Tool ${tool.name} already exists`)
+        }
         nativeCtx._tools.set(tool.name, tool)
         if (options?.signal) {
           options.signal.addEventListener('abort', () => {
-            nativeCtx._tools.delete(tool.name)
-          })
+            if (nativeCtx._tools.get(tool.name) === tool) {
+              nativeCtx._tools.delete(tool.name)
+            }
+          }, { once: true })
         }
       },
 

--- a/packages/next-wxt/test/mcpServer.test.ts
+++ b/packages/next-wxt/test/mcpServer.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setupLocalTools } from '../entrypoints/sidepanel/mcpServer'
+import { useExtraTools } from '../entrypoints/sidepanel/extraTools'
+
+vi.mock('../entrypoints/sidepanel/extraTools', () => ({
+  useExtraTools: vi.fn()
+}))
+vi.mock('../entrypoints/sidepanel/utils/utils', () => ({
+  getCurrentTabId: vi.fn().mockResolvedValue(1)
+}))
+
+// Mock wxt browser global
+global.browser = {
+  tabs: {
+    get: vi.fn().mockResolvedValue({ url: 'http://example.com' }),
+    onActivated: { addListener: vi.fn() },
+    onUpdated: { addListener: vi.fn() }
+  },
+  runtime: {
+    sendMessage: vi.fn().mockResolvedValue(undefined),
+    onMessage: { addListener: vi.fn() }
+  },
+  scripting: {
+    executeScript: vi.fn().mockResolvedValue([{ result: [] }])
+  }
+} as any
+
+describe('setupLocalTools - registerTool lifecycle', () => {
+  beforeEach(() => {
+    delete (globalThis as any).modelContext
+    if (typeof document !== 'undefined') {
+      delete (document as any).modelContext
+    }
+  })
+
+  it('复现：同名工具注册冲突及 AbortSignal 处理', () => {
+    setupLocalTools()
+    const ctx = (globalThis as any).modelContext
+    
+    // 1. 已中止 signal 不要注册
+    const abortedController = new AbortController()
+    abortedController.abort(new Error('Already aborted'))
+    const toolA = { name: 'test-tool-a', execute: async () => {} }
+    
+    const promise = ctx.registerTool(toolA, { signal: abortedController.signal })
+    await expect(promise).rejects.toThrow('Already aborted')
+    expect(ctx._tools.has('test-tool-a')).toBe(false)
+    
+    // 2. 正常注册并在 abort 时删除
+    const controller1 = new AbortController()
+    ctx.registerTool(toolA, { signal: controller1.signal })
+    expect(ctx._tools.has('test-tool-a')).toBe(true)
+    
+    // 3. 同名替换抛错
+    const toolA_duplicate = { name: 'test-tool-a', execute: async () => {} }
+    expect(() => ctx.registerTool(toolA_duplicate)).toThrow('Tool test-tool-a already exists')
+    
+    // 4. abort 监听器仅当 _tools.get(tool.name) === tool 时删除
+    // 这里因为是同一个 tool，会直接删除
+    controller1.abort()
+    expect(ctx._tools.has('test-tool-a')).toBe(false)
+    
+    // 验证同名覆盖被保护（强制伪造替换后，再调旧的 abort 不应删除新的）
+    const toolB1 = { name: 'test-tool-b' }
+    const controllerB1 = new AbortController()
+    ctx.registerTool(toolB1, { signal: controllerB1.signal })
+    
+    const toolB2 = { name: 'test-tool-b' }
+    // 强制绕过，直接在 _tools 替换（模拟异常或其它方式插入的同名工具）
+    ctx._tools.set('test-tool-b', toolB2)
+    
+    controllerB1.abort()
+    // 新的 toolB2 应被保留，不被删除
+    expect(ctx._tools.get('test-tool-b')).toBe(toolB2)
+  })
+})

--- a/packages/webmcp-cli/webmcp-tools/types.d.ts
+++ b/packages/webmcp-cli/webmcp-tools/types.d.ts
@@ -12,7 +12,7 @@ declare global {
      */
     modelContext: {
       registerTool: (tool: WebMcpToolDefinition) => void
-      unregisterTool: (name: string) => void
+
       notifyToolsChanged: () => void
     }
     /**

--- a/packages/webmcp-cli/webmcp-tools/types.d.ts
+++ b/packages/webmcp-cli/webmcp-tools/types.d.ts
@@ -8,18 +8,11 @@ declare global {
   interface Navigator {
     /**
      * WebMCP polyfill 注入的服务端接口（工具提供方使用）
-     * 用于注册/注销工具，对应 next-wxt 插件注入的 document.modelContext
+     * 用于注册工具，对应 next-wxt 插件注入的 document.modelContext
      */
     modelContext: {
-      registerTool: (tool: WebMcpToolDefinition) => void
-
+      registerTool: (tool: WebMcpToolDefinition, options?: { signal?: AbortSignal }) => void
       notifyToolsChanged: () => void
-    }
-    /**
-     * WebMCP polyfill 注入的客户端查询接口（工具调用方使用）
-     * 用于列举和调用已注册的工具
-     */
-    modelContext: {
       listTools: () => Promise<WebMcpToolDefinition[]>
       executeTool: (tool: any, argsJson: string) => Promise<unknown>
       registerToolsChangedCallback?: (cb: () => void) => void


### PR DESCRIPTION
…ecycle management of proxy tools

# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for canceling active tool registrations.
  * Re-registering a page agent now automatically cancels and replaces its previous registration.
  * Added improved cleanup for groups of proxy tools when they are no longer active.

* **Bug Fixes**
  * Improved tool lifecycle handling across page agents, side panels, and command-line tooling.
  * Prevented duplicate or stale tool registrations during replacement and shutdown.
  * Simplified automatic cleanup without requiring separate manual removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->