### PR TITLE
feat(next-sdk): 接管态默认只出呼吸灯，操作结束后收起光标，无参 showMask 不再默认露出鼠标，并新增 cursorMode 供宿主声明仅操作时展示。

### DIFF
--- a/docs/webmcp-sdk/page-agent-tool.md
+++ b/docs/webmcp-sdk/page-agent-tool.md
@@ -75,7 +75,7 @@ getPageAgentToolConfig() // { enableHighlight: false, a11yConfig: { roles: [...]
 `registerPageAgentTool` 返回 `{ showMask, hideMask }`。遮罩（呼吸灯锁屏）与 AI 鼠标光标是两套视觉：
 
 - **接管态**（宿主 `showMask()`、感知/滚动类 action）：默认只出呼吸灯，不出光标。
-- **操作类**（`click` / `fill` / `select` / `hover`）：步骤期间出光标，结束后若遮罩仍开着则自动收起光标。
+- **操作类**（`click` / `fill` / `select` / `hover`）：步骤期间出光标；结束后若遮罩仍开着且 `cursorMode !== 'always'`，则自动收起光标。
 
 ```typescript
 const handle = registerPageAgentTool({ removeMaskAfterToolCall: false })
@@ -94,8 +94,8 @@ await handle.hideMask()
 
 | `cursorMode` | 含义 |
 | --- | --- |
-| `actionOnly`（默认） | 仅操作类步骤展示光标，结束后收起 |
-| `always` | 遮罩可见期间始终展示光标 |
+| `actionOnly`（默认） | 仅操作类步骤展示光标；结束后若遮罩仍开着则收起 |
+| `always` | 未传 `showCursor` 时遮罩可见即展示光标；显式 `{ showCursor: false }` 仍可临时隐藏；操作结束后不自动收起 |
 | `never` | 任何路径都不展示光标（含宿主显式 `showCursor: true`） |
 
 ```typescript

--- a/docs/webmcp-sdk/page-agent-tool.md
+++ b/docs/webmcp-sdk/page-agent-tool.md
@@ -7,17 +7,19 @@
 **类型签名**
 
 ```typescript
-import { PageAgentToolOptions } from '@opentiny/next-sdk'
+import { PageAgentToolOptions, PageAgentToolHandle } from '@opentiny/next-sdk'
 
-export function registerPageAgentTool(options?: PageAgentToolOptions): void
+export function registerPageAgentTool(options?: PageAgentToolOptions): PageAgentToolHandle
 ```
 
 ## PageAgentToolOptions 配置项说明
 
-| 属性名            | 类型         | 默认值  | 说明                                                    |
-| :---------------- | :----------- | :------ | :------------------------------------------------------ |
-| `enableHighlight` | `boolean`    | `false` | 是否在页面中高亮标注可交互的元素。                      |
-| `a11yConfig`      | `A11yConfig` | -       | 统一无障碍配置，见下文「统一无障碍配置 `a11yConfig`」。 |
+| 属性名                   | 类型                                      | 默认值        | 说明                                                                 |
+| :----------------------- | :---------------------------------------- | :------------ | :------------------------------------------------------------------- |
+| `enableHighlight`        | `boolean`                                 | `false`       | 是否在页面中高亮标注可交互的元素。                                   |
+| `removeMaskAfterToolCall`| `boolean`                                 | `true`        | 是否在每次工具调用后移除遮罩。宿主接管 Tab 期间通常设为 `false`。    |
+| `cursorMode`             | `'actionOnly' \| 'always' \| 'never'`     | `'actionOnly'`| 鼠标光标展示策略，见下文「遮罩与光标」。                             |
+| `a11yConfig`             | `A11yConfig`                              | -             | 统一无障碍配置，见下文「统一无障碍配置 `a11yConfig`」。              |
 
 `PageAgentToolOptions` 中的所有配置项（含 `enableHighlight` 与 `a11yConfig`）都由同一个 `PageAgentToolConfig` 类型描述，只有唯一一套运行期读写 API：`getPageAgentToolConfig`/`setPageAgentToolConfig`。除了在 `registerPageAgentTool(options)` 时初始化一次，也可以在页面运行期随时读取/修改（例如路由切换后为新页面追加规则、临时关闭高亮）：
 
@@ -65,6 +67,40 @@ getPageAgentToolConfig() // { enableHighlight: false, a11yConfig: { roles: [...]
 | `clipboard`         | 读写系统剪切板              | `text`（见下文）                         |
 
 执行 `click`、`fill`、`select`、`hover` 前通常需先调用 `browserState` 获取最新 ref 索引；`clipboard` 不依赖 `index`，也不展示 SimulatorMask。
+
+---
+
+## 遮罩与光标
+
+`registerPageAgentTool` 返回 `{ showMask, hideMask }`。遮罩（呼吸灯锁屏）与 AI 鼠标光标是两套视觉：
+
+- **接管态**（宿主 `showMask()`、感知/滚动类 action）：默认只出呼吸灯，不出光标。
+- **操作类**（`click` / `fill` / `select` / `hover`）：步骤期间出光标，结束后若遮罩仍开着则自动收起光标。
+
+```typescript
+const handle = registerPageAgentTool({ removeMaskAfterToolCall: false })
+
+// 初始化 / 思考阶段：仅呼吸灯
+await handle.showMask()
+// 等价于 handle.showMask({ showCursor: false })
+
+// 需要强制出光标时再显式传入
+await handle.showMask({ showCursor: true })
+
+await handle.hideMask()
+```
+
+运行期可用 `cursorMode` 覆盖默认策略：
+
+| `cursorMode` | 含义 |
+| --- | --- |
+| `actionOnly`（默认） | 仅操作类步骤展示光标，结束后收起 |
+| `always` | 遮罩可见期间始终展示光标 |
+| `never` | 任何路径都不展示光标（含宿主显式 `showCursor: true`） |
+
+```typescript
+setPageAgentToolConfig({ cursorMode: 'never' })
+```
 
 ---
 

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/index.ts
+++ b/packages/next-sdk/index.ts
@@ -53,7 +53,7 @@ export { initializeBuiltinWebMCP } from './page-tools/initialize-builtin-WebMCP'
 export { waitForRouteTools } from './page-tools/wait-for-route-tools'
 export type { RouteToolsMap, WaitForRouteToolsOptions } from './page-tools/wait-for-route-tools'
 export { registerPageAgentTool } from './page-tools/page-agent-tool'
-export type { PageAgentToolHandle } from './page-tools/page-agent-tool'
+export type { PageAgentToolHandle, ShowMaskOptions } from './page-tools/page-agent-tool'
 export {
   PAGE_AGENT_TOOL_CALL_EVENT,
   PAGE_AGENT_TOOL_RESULT_EVENT,
@@ -74,7 +74,7 @@ export {
   getPageAgentToolConfig,
   setPageAgentToolConfig
 } from './page-tools/tool-config'
-export type { PageAgentToolConfig, PageAgentToolConfigPatch } from './page-tools/tool-config'
+export type { PageAgentToolConfig, PageAgentToolConfigPatch, PageAgentCursorMode } from './page-tools/tool-config'
 
 // 站点预设：云控制台（consoleCloud）等 PageAgentToolOptions，可直接传给 registerPageAgentTool
 export { consoleCloudPageAgentToolOptions, isConsoleCloudHost } from './page-tools/configs/console-cloud'

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.7",
+  "version": "0.4.8",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/handlers/executeJavascript.ts
+++ b/packages/next-sdk/page-tools/handlers/executeJavascript.ts
@@ -15,7 +15,6 @@ export async function handleExecuteJavascript(args: any, ctx: ActionContext) {
       // 表达式求值也失败（如含 await/let/const 等语句），保持 undefined
     }
   }
-  await ctx.pageController.hideMask()
   return {
     content: [{ type: 'text' as const, text: `脚本执行结果: ${JSON.stringify(result)}` }]
   }

--- a/packages/next-sdk/page-tools/handlers/searchTree.ts
+++ b/packages/next-sdk/page-tools/handlers/searchTree.ts
@@ -15,7 +15,6 @@ export async function handleSearchTree(args: PageAgentToolInput, ctx: ActionCont
   ctx.setRefMap(result.refMap)
   ctx.stateCache.update(window.location.href, result.yaml)
 
-  await ctx.pageController.hideMask()
   // 检测页面弹窗/校验错误，平铺为结构化字段（与 browserState 对齐）
   const dialogs = detectPageDialog()
   const validationErrors = detectValidationErrors()

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -4,6 +4,7 @@ import { isPageDark } from './checkDarkMode'
 
 const injectStyles = `
 .webmcp-page-agent-cursor {
+	display: none;
 	position: absolute;
 	width: var(--cursor-size, 75px);
 	height: var(--cursor-size, 75px);
@@ -233,10 +234,10 @@ export class SimulatorMask extends EventTarget {
 
     // 根据 showCursor 动态控制鼠标图标显隐（默认 false：遮罩 ≠ 正在鼠标操作）
     const showCursor = options?.showCursor ?? false
-    const wasHidden = this.#cursor.style.display === 'none'
+    const wasHidden = this.#cursor.style.display === 'none' || !this.#cursor.style.display
 
     if (showCursor) {
-      this.#cursor.style.display = ''
+      this.#cursor.style.display = 'block'
       // 遮罩首次开启或 cursor 刚从隐藏切为显示时，重置初始坐标到视口中心
       if (!this.shown || wasHidden) {
         this.#currentCursorX = window.innerWidth / 2

--- a/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
+++ b/packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts
@@ -179,6 +179,8 @@ export class SimulatorMask extends EventTarget {
     // this.#cursor.appendChild(borderLayer)
 
     this.wrapper.appendChild(this.#cursor)
+    // 接管态默认只出呼吸灯；未显式 showCursor 前不得以 (0,0) 露出光标
+    this.#cursor.style.display = 'none'
   }
 
   #moveCursorToTarget() {
@@ -229,8 +231,8 @@ export class SimulatorMask extends EventTarget {
   show(options?: { showCursor?: boolean }) {
     if (this.#disposed) return
 
-    // 根据 showCursor 动态控制鼠标图标显隐（默认 true）
-    const showCursor = options?.showCursor ?? true
+    // 根据 showCursor 动态控制鼠标图标显隐（默认 false：遮罩 ≠ 正在鼠标操作）
+    const showCursor = options?.showCursor ?? false
     const wasHidden = this.#cursor.style.display === 'none'
 
     if (showCursor) {

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -24,10 +24,25 @@ import { handleSearchTree } from './handlers/searchTree'
 import { handleHover } from './handlers/hover'
 import { handleClipboard } from './handlers/clipboard'
 
-/** registerPageAgentTool 返回的句柄，暴露对内部 PageController mask 显隐的控制 */
+/** 宿主调用 showMask 时可覆盖是否展示 AI 鼠标图标 */
+export type ShowMaskOptions = {
+  showCursor?: boolean
+}
+
+/** registerPageAgentTool 返回的句柄，暴露对内部 SimulatorMask 显隐的控制 */
 export type PageAgentToolHandle = {
-  showMask: () => Promise<void>
+  showMask: (options?: ShowMaskOptions) => Promise<void>
   hideMask: () => Promise<void>
+}
+
+type CursorKind = 'host' | 'pointer' | 'observe'
+
+function resolveShowCursor(kind: CursorKind, explicit?: boolean): boolean {
+  const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+  if (mode === 'never') return false
+  if (explicit !== undefined) return explicit
+  if (mode === 'always') return true
+  return kind === 'pointer'
 }
 
 /** 在浏览器页面中注册 page-agent-tool, 用于页面的内容获取和操作，页面的动效 */
@@ -152,6 +167,29 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
     if (el) simulatorMask.borderElement(el)
   }
 
+  function showMaskFor(kind: CursorKind) {
+    simulatorMask.show({ showCursor: resolveShowCursor(kind) })
+  }
+
+  function hideCursorKeepMask() {
+    const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+    if (mode === 'always') return
+    if (simulatorMask.shown) {
+      simulatorMask.show({ showCursor: false })
+    }
+  }
+
+  function createHandle(): PageAgentToolHandle {
+    return {
+      showMask: async (options?: ShowMaskOptions) => {
+        simulatorMask.show({ showCursor: resolveShowCursor('host', options?.showCursor) })
+      },
+      hideMask: async () => {
+        simulatorMask.hide()
+      }
+    }
+  }
+
   async function executePageAgentTool(args: PageAgentToolInput) {
     try {
       let ret: { content: Array<{ type: 'text'; text: string }> }
@@ -159,13 +197,13 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       switch (args.action) {
         // ─── 感知/脚本类：仅呼吸灯，无鼠标图标 ──────────────────────────────
         case 'browserState':
-          simulatorMask.show({ showCursor: false })
+          showMaskFor('observe')
           ret = await handleBrowserState(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'executeJavascript':
           if (getPageAgentToolConfig().enableExecuteJavascript) {
-            simulatorMask.show({ showCursor: false })
+            showMaskFor('observe')
             ret = await handleExecuteJavascript(args, actionContext)
             getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           } else {
@@ -173,37 +211,37 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
           }
           break
         case 'searchTree':
-          simulatorMask.show({ showCursor: false })
+          showMaskFor('observe')
           ret = await handleSearchTree(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         // ─── 滚动类：仅呼吸灯，无静止鼠标图标 ───────────────────────────────
         case 'scroll':
-          simulatorMask.show({ showCursor: false })
+          showMaskFor('observe')
           ret = await handleScroll(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         // ─── 精准操作类：呼吸灯 + 鼠标图标 ─────────────────────────────────
         case 'click':
-          simulatorMask.show({ showCursor: true })
+          showMaskFor('pointer')
           borderTargetElement(args.index)
           ret = await handleClick(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'fill':
-          simulatorMask.show({ showCursor: true })
+          showMaskFor('pointer')
           borderTargetElement(args.index)
           ret = await handleFill(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'select':
-          simulatorMask.show({ showCursor: true })
+          showMaskFor('pointer')
           borderTargetElement(args.index)
           ret = await handleSelect(args, actionContext)
           getPageAgentToolConfig().removeMaskAfterToolCall && (await pageController.hideMask())
           break
         case 'hover':
-          simulatorMask.show({ showCursor: true })
+          showMaskFor('pointer')
           borderTargetElement(args.index)
           const el = args.index !== undefined ? currentRefMap.get(args.index) : undefined
           if (el) {
@@ -236,6 +274,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       throw error
     } finally {
       simulatorMask.removeBorderElement()
+      hideCursorKeepMask()
     }
   }
 
@@ -244,10 +283,7 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
   const modelContext = (document as any).modelContext
   if (!modelContext) {
     console.warn('[next-sdk] modelContext is not available, skipping page-agent-tool registration.')
-    return {
-      showMask: () => pageController.showMask(),
-      hideMask: () => pageController.hideMask()
-    }
+    return createHandle()
   }
   try {
     if ((window as any).__pageAgentToolAbortController) {
@@ -283,8 +319,5 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
 
   setupPageAgentToolEventBridge(executePageAgentTool, pageController, actionContext)
 
-  return {
-    showMask: () => pageController.showMask(),
-    hideMask: () => pageController.hideMask()
-  }
+  return createHandle()
 }

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -39,6 +39,7 @@ type CursorKind = 'host' | 'pointer' | 'observe'
 
 function resolveShowCursor(kind: CursorKind, explicit?: boolean): boolean {
   const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+  // 优先级：never（全局关闭）> 显式 showCursor > always（未传参时默认出光标）> actionOnly 按 kind
   if (mode === 'never') return false
   if (explicit !== undefined) return explicit
   if (mode === 'always') return true

--- a/packages/next-sdk/page-tools/tool-config.ts
+++ b/packages/next-sdk/page-tools/tool-config.ts
@@ -9,6 +9,9 @@
 import type { A11yConfig, ResolvedA11yConfig } from './a11y/config'
 import { DEFAULT_A11Y_CONFIG, mergeA11yConfig, mergeA11yConfigs } from './a11y/config'
 
+/** 鼠标光标展示策略：仅操作类展示（默认） / 遮罩期间始终展示 / 永不展示 */
+export type PageAgentCursorMode = 'actionOnly' | 'always' | 'never'
+
 export interface PageAgentToolConfig {
   /** 是否启用元素高亮 */
   enableHighlight: boolean
@@ -16,6 +19,13 @@ export interface PageAgentToolConfig {
   removeMaskAfterToolCall?: boolean
   /** 是否启用执行 JavaScript 工具 */
   enableExecuteJavascript?: boolean
+  /**
+   * 鼠标光标展示策略。
+   * - `actionOnly`（默认）：仅 click/fill/select/hover 期间展示，步骤结束后收起
+   * - `always`：遮罩可见即展示光标
+   * - `never`：任何路径都不展示光标
+   */
+  cursorMode: PageAgentCursorMode
   /**
    * 统一无障碍配置：按角色（roles）、状态（states：selected/disabled/error/warning 等）自定义规则，
    * 以及白名单/黑名单/自定义暴露属性/弹窗选择器。已与默认配置合并（数组类字段是拼接结果）。
@@ -34,6 +44,8 @@ export interface PageAgentToolConfigPatch {
   removeMaskAfterToolCall?: boolean
   /** 是否启用执行 JavaScript 工具 */
   enableExecuteJavascript?: boolean
+  /** 鼠标光标展示策略，见 {@link PageAgentCursorMode} */
+  cursorMode?: PageAgentCursorMode
   /** 统一无障碍配置，会与当前生效的 a11yConfig 按数组拼接合并 */
   a11yConfig?: A11yConfig
 }
@@ -46,6 +58,7 @@ export const DEFAULT_PAGE_AGENT_TOOL_CONFIG: PageAgentToolConfig = {
   enableHighlight: false,
   removeMaskAfterToolCall: true,
   enableExecuteJavascript: true,
+  cursorMode: 'actionOnly',
   a11yConfig: DEFAULT_A11Y_CONFIG
 }
 
@@ -65,6 +78,7 @@ export function getPageAgentToolConfig(): PageAgentToolConfig {
     enableHighlight: DEFAULT_PAGE_AGENT_TOOL_CONFIG.enableHighlight,
     removeMaskAfterToolCall: DEFAULT_PAGE_AGENT_TOOL_CONFIG.removeMaskAfterToolCall,
     enableExecuteJavascript: DEFAULT_PAGE_AGENT_TOOL_CONFIG.enableExecuteJavascript,
+    cursorMode: DEFAULT_PAGE_AGENT_TOOL_CONFIG.cursorMode,
     a11yConfig: mergeA11yConfig()
   }
 }
@@ -74,6 +88,7 @@ function resolvePatch(patch: PageAgentToolConfigPatch, base: PageAgentToolConfig
     enableHighlight: patch.enableHighlight ?? base.enableHighlight,
     removeMaskAfterToolCall: patch.removeMaskAfterToolCall ?? base.removeMaskAfterToolCall,
     enableExecuteJavascript: patch.enableExecuteJavascript ?? base.enableExecuteJavascript,
+    cursorMode: patch.cursorMode ?? base.cursorMode,
     a11yConfig: mergeA11yConfigs(base.a11yConfig, patch.a11yConfig ?? {})
   }
 }

--- a/packages/next-sdk/page-tools/tool-config.ts
+++ b/packages/next-sdk/page-tools/tool-config.ts
@@ -22,8 +22,8 @@ export interface PageAgentToolConfig {
   /**
    * 鼠标光标展示策略。
    * - `actionOnly`（默认）：仅 click/fill/select/hover 期间展示，步骤结束后收起
-   * - `always`：遮罩可见即展示光标
-   * - `never`：任何路径都不展示光标
+   * - `always`：未传 showCursor 时遮罩可见即展示光标；显式 `{ showCursor: false }` 仍可临时隐藏；操作结束后不自动收起
+   * - `never`：任何路径都不展示光标（含宿主显式 `showCursor: true`）
    */
   cursorMode: PageAgentCursorMode
   /**
@@ -94,11 +94,27 @@ function resolvePatch(patch: PageAgentToolConfigPatch, base: PageAgentToolConfig
 }
 
 /**
+ * 函数式 patch：标量与 current 合并（未返回的字段保持原值）；
+ * 若返回了 a11yConfig，则与默认无障碍配置合并，避免再与 current 相加让已过滤规则复活。
+ */
+function resolveFunctionPatch(fnPatch: PageAgentToolConfigPatch, current: PageAgentToolConfig): PageAgentToolConfig {
+  return {
+    enableHighlight: fnPatch.enableHighlight ?? current.enableHighlight,
+    removeMaskAfterToolCall: fnPatch.removeMaskAfterToolCall ?? current.removeMaskAfterToolCall,
+    enableExecuteJavascript: fnPatch.enableExecuteJavascript ?? current.enableExecuteJavascript,
+    cursorMode: fnPatch.cursorMode ?? current.cursorMode,
+    a11yConfig:
+      fnPatch.a11yConfig !== undefined
+        ? mergeA11yConfigs(DEFAULT_PAGE_AGENT_TOOL_CONFIG.a11yConfig, fnPatch.a11yConfig)
+        : current.a11yConfig
+  }
+}
+
+/**
  * 更新当前生效配置。
- * - patch 为对象时：enableHighlight 覆盖式更新；a11yConfig 与当前配置按数组拼接合并（不丢已有规则）
- * - patch 为函数时：入参为当前生效配置，返回值直接与默认配置合并（而不是再与 current 相加）。
- *   这样函数体内可以对 current.a11yConfig 做任意过滤/裁剪（如按条件"移除"某条旧规则），
- *   返回值即为最终生效的配置，不会因为再与 current 相加而让被过滤掉的旧规则"复活"
+ * - patch 为对象时：enableHighlight / cursorMode 等标量覆盖式更新；a11yConfig 与当前配置按数组拼接合并（不丢已有规则）
+ * - patch 为函数时：入参为当前生效配置。标量字段与 current 合并（未返回则保持原值，例如只改高亮不会重置 cursorMode）；
+ *   若返回了 a11yConfig，则与默认无障碍配置合并（而不是再与 current 相加），以便过滤后的规则不会复活。
  * - options.mode = 'replace' 时（仅影响对象类型的 patch）：不与"当前生效配置"合并，而是与默认配置重新合并
  * 返回合并后的最新完整配置，并写回运行期存储供 buildBrowserStateResponse/buildA11yTree 等读取。
  */
@@ -111,7 +127,7 @@ export function setPageAgentToolConfig(
 
   const next =
     typeof patch === 'function'
-      ? resolvePatch(patch(current), DEFAULT_PAGE_AGENT_TOOL_CONFIG)
+      ? resolveFunctionPatch(patch(current), current)
       : resolvePatch(patch, mode === 'replace' ? DEFAULT_PAGE_AGENT_TOOL_CONFIG : current)
 
   if (typeof window !== 'undefined') {

--- a/packages/next-sdk/skills/page-agent/SKILL.md
+++ b/packages/next-sdk/skills/page-agent/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 - 无障碍树构建、剪枝、Static-Lift、序列化语义
 - 需要更新 `docs/webmcp-sdk/page-agent-tool.md` 的行为说明
 
-近期示例：[`specs/REQ-20260722-console-layout-landmark/`](../../specs/REQ-20260722-console-layout-landmark/)、[`specs/REQ-20260817-clipboard-handler/`](../../specs/REQ-20260817-clipboard-handler/)。
+近期示例：[`specs/REQ-20260722-console-layout-landmark/`](../../specs/REQ-20260722-console-layout-landmark/)、[`specs/REQ-20260817-clipboard-handler/`](../../specs/REQ-20260817-clipboard-handler/)、[`specs/REQ-20260903-mask-cursor-lifecycle/`](../../specs/REQ-20260903-mask-cursor-lifecycle/)。
 
 拿不准是否琐碎 → **先问用户**，不要默认开写。
 
@@ -54,8 +54,9 @@ import {
 } from '@opentiny/next-sdk'
 ```
 
-- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`；重复调用为 **replace** 式重新初始化。
-- 运行期唯一配置面：`getPageAgentToolConfig` / `setPageAgentToolConfig`（`a11yConfig` 数组合并；`enableHighlight` 覆盖；支持 `mode: 'replace'`）。
+- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。
+- 运行期唯一配置面：`getPageAgentToolConfig` / `setPageAgentToolConfig`（`a11yConfig` 数组合并；`enableHighlight` / `cursorMode` 覆盖；支持 `mode: 'replace'`）。
+- `cursorMode`：`'actionOnly'`（默认，仅操作类出光标） / `'always'` / `'never'`。无参 `showMask()` 默认不出光标；操作类结束后若遮罩仍开着则收光标。
 - `whitelist` / `blacklist` 中的选择器字符串在构建无障碍树时 **动态解析**。
 - `A11yRoleRule.name`：可选声明可访问名（不改 DOM），用于 landmark / 布局容器在 YAML 中保留分区名。
 - 站点预设：云控制台用 `consoleCloudPageAgentToolOptions` + `isConsoleCloudHost()`（含 `ti-app-layout-*` landmark）。

--- a/packages/next-sdk/skills/page-agent/SKILL.md
+++ b/packages/next-sdk/skills/page-agent/SKILL.md
@@ -56,7 +56,7 @@ import {
 
 - `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。
 - 运行期唯一配置面：`getPageAgentToolConfig` / `setPageAgentToolConfig`（`a11yConfig` 数组合并；`enableHighlight` / `cursorMode` 覆盖；支持 `mode: 'replace'`）。
-- `cursorMode`：`'actionOnly'`（默认，仅操作类出光标） / `'always'` / `'never'`。无参 `showMask()` 默认不出光标；操作类结束后若遮罩仍开着则收光标。
+- `cursorMode`：`'actionOnly'`（默认，仅操作类出光标） / `'always'` / `'never'`。无参 `showMask()` 默认不出光标；操作类结束后若遮罩仍开着且 `cursorMode !== 'always'` 则收光标。`always` 下显式 `{ showCursor: false }` 仍可临时隐藏；`never` 覆盖显式 `showCursor: true`。
 - `whitelist` / `blacklist` 中的选择器字符串在构建无障碍树时 **动态解析**。
 - `A11yRoleRule.name`：可选声明可访问名（不改 DOM），用于 landmark / 布局容器在 YAML 中保留分区名。
 - 站点预设：云控制台用 `consoleCloudPageAgentToolOptions` + `isConsoleCloudHost()`（含 `ti-app-layout-*` landmark）。

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,6 +20,7 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260903-mask-cursor-lifecycle`](./REQ-20260903-mask-cursor-lifecycle/) | 遮罩接管态默认不出光标；句柄透传 `showCursor`；操作结束收光标；`cursorMode` |
 | [`REQ-20260817-clipboard-handler`](./REQ-20260817-clipboard-handler/) | Page Agent `clipboard` action：读写系统剪切板（`text` 有值写、无值读） |
 | [`REQ-20260807-dev-entry`](./REQ-20260807-dev-entry/) | 新增 `dev` 入口：将 `dom-inspect` 等本地开发能力从主入口拆出 |
 | [`REQ-20260729-user-do-action`](./REQ-20260729-user-do-action/) | mask 展示期间用户 trusted 点击 → `page-agent-user-do-action` 事件 |

--- a/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/design.md
+++ b/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/design.md
@@ -1,0 +1,140 @@
+# Design：遮罩接管态与光标生命周期分离
+
+## 方案概述
+
+把「遮罩是否可见」和「光标是否可见」彻底解耦：`show()` 默认只开呼吸灯；宿主句柄可传 `showCursor`；操作类步骤结束后若遮罩仍在则收光标；运行期 `cursorMode` 作为全局策略覆盖默认解析。
+
+`pageController.showMask()` 无参、无法透传，句柄改为直调已构造好的 `simulatorMask.show(options)`。
+
+## 涉及模块 / 文件
+
+| 路径 | 职责 |
+| --- | --- |
+| `page-tools/page-agent-mask/SimulatorMask.ts` | 光标初始隐藏；`show()` 默认 `showCursor: false` |
+| `page-tools/page-agent-tool.ts` | 句柄透传；`finally` 收光标；按 `cursorMode` 解析 |
+| `page-tools/tool-config.ts` | `cursorMode` 配置面 |
+| `test/page-tools/simulator-mask-cursor.test.ts` | 默认隐藏 / 初始 display |
+| `test/page-tools/page-agent-tool-dispatch.test.ts` | 操作结束收光标、`cursorMode` |
+| `test/page-tools/page-agent-tool.test.ts` | 句柄传参 |
+| `test/page-tools/tool-config.test.ts` | `cursorMode` 读写 |
+| `docs/webmcp-sdk/page-agent-tool.md` | 用户文档 |
+| `skills/page-agent/SKILL.md` | 编码 Agent Skill |
+
+## 核心数据结构 / 类型定义
+
+```typescript
+export type PageAgentCursorMode = 'actionOnly' | 'always' | 'never'
+
+export type ShowMaskOptions = {
+  /** 是否显示 AI 鼠标图标；未传时由 cursorMode 决定（actionOnly 下为 false） */
+  showCursor?: boolean
+}
+
+export type PageAgentToolHandle = {
+  showMask: (options?: ShowMaskOptions) => Promise<void>
+  hideMask: () => Promise<void>
+}
+
+export interface PageAgentToolConfig {
+  // ...既有字段
+  /** 鼠标光标展示策略，默认 'actionOnly' */
+  cursorMode: PageAgentCursorMode
+}
+```
+
+### `cursorMode` 与显式 `showCursor` 的解析
+
+```typescript
+type CursorKind = 'host' | 'pointer' | 'observe'
+
+function resolveShowCursor(kind: CursorKind, explicit?: boolean): boolean {
+  const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+  if (mode === 'never') return false
+  if (explicit !== undefined) return explicit
+  if (mode === 'always') return true
+  return kind === 'pointer'
+}
+```
+
+| 场景 | actionOnly（默认） | always | never |
+| --- | --- | --- | --- |
+| 宿主 `showMask()` 无参 | 否 | 是 | 否 |
+| 宿主 `showMask({ showCursor: true })` | 是 | 是 | 否（never 优先） |
+| 操作类 action | 是（结束后收起） | 是（结束后不收） | 否 |
+| 感知/滚动类 Action | 否 | 是 | 否 |
+
+## API / 行为变更
+
+| 符号或行为 | 变更类型 | 说明 |
+|---|---|---|
+| `SimulatorMask.show()` | 修改 | 默认 `showCursor`：`true` → `false` |
+| `SimulatorMask.#createCursor()` | 修改 | 初始 `style.display = 'none'` |
+| `PageAgentToolHandle.showMask` | 修改 | 可传 `ShowMaskOptions`；直调 `simulatorMask.show` |
+| `executePageAgentTool` `finally` | 修改 | `shown && cursorMode !== 'always'` 时 `show({ showCursor: false })` |
+| `PageAgentToolConfig.cursorMode` | 新增 | 默认 `'actionOnly'` |
+
+## 数据流 / 时序
+
+```mermaid
+sequenceDiagram
+  participant Host
+  participant Handle as PageAgentToolHandle
+  participant Mask as SimulatorMask
+  participant Tool as executePageAgentTool
+
+  Host->>Handle: showMask()
+  Handle->>Mask: show({ showCursor: false })
+  Note over Mask: 仅呼吸灯，光标 display:none
+
+  Tool->>Mask: show({ showCursor: true })
+  Note over Mask: click/fill/select/hover 期间出光标
+  Tool->>Mask: removeBorderElement()
+  Tool->>Mask: show({ showCursor: false })
+  Note over Mask: 步骤结束，遮罩仍在则收光标
+```
+
+## 实现细节
+
+### SimulatorMask
+
+- `#createCursor()` 末尾：`this.#cursor.style.display = 'none'`。
+- `show()`：`const showCursor = options?.showCursor ?? false`。
+- `hide()` 保持现有「fadeOut 期间也 `display: none`」，无需改回 `''`。
+
+### 句柄
+
+```typescript
+showMask: async (options?: ShowMaskOptions) => {
+  simulatorMask.show({ showCursor: resolveShowCursor('host', options?.showCursor) })
+},
+hideMask: async () => {
+  simulatorMask.hide()
+}
+```
+
+两处 return（`modelContext` 缺失提前返回、正常注册返回）共用同一实现，避免再转发无参的 `pageController.showMask()`。
+
+### finally 收光标
+
+```typescript
+} finally {
+  simulatorMask.removeBorderElement()
+  const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+  if (mode !== 'always' && simulatorMask.shown) {
+    simulatorMask.show({ showCursor: false })
+  }
+}
+```
+
+`removeMaskAfterToolCall === true` 时分支内已 `hideMask()`，`shown === false`，finally 不会把遮罩重新打开。
+
+## 风险与兼容
+
+- **有意不兼容**：无参 `show()` / `showMask()` 不再出光标。这是本需求的修复目标；需要光标的调用方改为显式 `{ showCursor: true }` 或 `cursorMode: 'always'`。
+- `never` 覆盖宿主显式 `showCursor: true`，避免全局关闭被单次调用打破。
+- 不修改外部 `@page-agent/page-controller` 签名。
+
+## 备选方案
+
+- 仅改默认值、不加 `cursorMode`：宿主无法声明 always/never，扩展性不足。
+- 单独 `hideCursor()` 方法：语义更直，但 `show({ showCursor: false })` 已覆盖且不增加 API。

--- a/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/design.md
+++ b/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/design.md
@@ -44,11 +44,16 @@ export interface PageAgentToolConfig {
 
 ### `cursorMode` 与显式 `showCursor` 的解析
 
+优先级（高 → 低）：`never`（全局关闭）> 显式 `showCursor` > `always`（未传参时默认出光标）> `actionOnly` 按 action 种类。
+
+因此 `always` 不是绝对锁死：`showMask({ showCursor: false })` 仍可临时隐藏；操作结束的自动收光标仅在 `cursorMode !== 'always'` 时发生。
+
 ```typescript
 type CursorKind = 'host' | 'pointer' | 'observe'
 
 function resolveShowCursor(kind: CursorKind, explicit?: boolean): boolean {
   const mode = getPageAgentToolConfig().cursorMode ?? 'actionOnly'
+  // 优先级：never > 显式 showCursor > always > actionOnly 按 kind
   if (mode === 'never') return false
   if (explicit !== undefined) return explicit
   if (mode === 'always') return true
@@ -60,6 +65,7 @@ function resolveShowCursor(kind: CursorKind, explicit?: boolean): boolean {
 | --- | --- | --- | --- |
 | 宿主 `showMask()` 无参 | 否 | 是 | 否 |
 | 宿主 `showMask({ showCursor: true })` | 是 | 是 | 否（never 优先） |
+| 宿主 `showMask({ showCursor: false })` | 否 | 否（显式优先于 always） | 否 |
 | 操作类 action | 是（结束后收起） | 是（结束后不收） | 否 |
 | 感知/滚动类 Action | 否 | 是 | 否 |
 
@@ -132,6 +138,7 @@ hideMask: async () => {
 
 - **有意不兼容**：无参 `show()` / `showMask()` 不再出光标。这是本需求的修复目标；需要光标的调用方改为显式 `{ showCursor: true }` 或 `cursorMode: 'always'`。
 - `never` 覆盖宿主显式 `showCursor: true`，避免全局关闭被单次调用打破。
+- `always` 不覆盖显式 `showCursor: false`：策略决定默认值，单次调用仍可临时隐藏。
 - 不修改外部 `@page-agent/page-controller` 签名。
 
 ## 备选方案

--- a/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/requirements.md
@@ -1,0 +1,80 @@
+# Spec：遮罩接管态与光标生命周期分离
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`
+- 关联 Issue：无（用户口头 / 架构评审需求）
+- 前序 Spec：[`REQ-20260810-mask-cursor-split`](../REQ-20260810-mask-cursor-split/)（引入 `showCursor`，但默认值写反）
+
+## 背景
+
+`REQ-20260810` 已将呼吸灯与鼠标图标分层，但宿主在「准备中 / 思考中」接管 Tab 时仍会看到光标，根因有四处断层：
+
+1. **`PageAgentToolHandle.showMask()` 无法传参**，且内部落到 `SimulatorMask.show()` 时 `options?.showCursor ?? true`，无参即露光标。
+2. **`#createCursor()` 未设 `display: 'none'`**，wrapper 一旦 `.visible`，光标以 `(0, 0)` 瞬时露出。
+3. **操作类 action 的 `finally` 只 `removeBorderElement()`**，不收起光标；宿主保持遮罩期间光标停在上次点击位置。
+4. **缺少运行期策略配置**，扩展宿主无法声明「仅操作时出光标 / 永远不出 / 始终出」。
+
+遮罩（Mask）语义是呼吸灯锁屏防误触；光标（Cursor）语义是操作动效。开启接管态 ≠ 正在鼠标操作。
+
+## 领域术语表
+
+- **接管态**：宿主（Sidepanel / 子 Agent）对当前 Tab 调用 `showMask()`，展示呼吸灯并拦截误触。
+- **操作类 Action**：`click` / `fill` / `select` / `hover`，需要光标移动到目标。
+- **感知/脚本/滚动类 Action**：`browserState` / `searchTree` / `executeJavascript` / `scroll`，只需呼吸灯。
+- **`cursorMode`**：运行期光标策略。`actionOnly`（默认）仅操作类展示；`always` 遮罩可见即展示；`never` 永不展示。
+
+## 目标用户 / 场景
+
+- 扩展宿主在 lockTask / beginTaskSession 时只需呼吸灯，初始化与思考阶段不得出现鼠标。
+- 最终用户观察 AI 点击/填写时，光标仅在该步骤期间出现，步骤结束后收回。
+- 集成方可通过 `cursorMode` 覆盖默认策略。
+
+## 参考资料 / 上下文
+
+- `packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts`
+- `packages/next-sdk/page-tools/page-agent-tool.ts`（`PageAgentToolHandle`、`executePageAgentTool`）
+- `packages/next-sdk/page-tools/tool-config.ts`
+- 前序：`specs/REQ-20260810-mask-cursor-split/`、`specs/REQ-20260722-mask-handle/`
+
+## 范围
+
+### In Scope
+
+- `SimulatorMask.#createCursor()` 初始 `display: 'none'`。
+- `SimulatorMask.show()` 默认 `showCursor: false`（破坏性默认值修正）。
+- `PageAgentToolHandle.showMask(options?)` 透传 `{ showCursor?: boolean }`，内部直调 `simulatorMask.show`（不经无参的 `pageController.showMask()`）。
+- 操作类 Action 结束后，若遮罩仍显示且 `cursorMode !== 'always'`，自动 `show({ showCursor: false })`。
+- `PageAgentToolConfig.cursorMode`：`'actionOnly' | 'always' | 'never'`，默认 `'actionOnly'`。
+- 对应单元测试与用户文档。
+
+### Out of Scope
+
+- 修改 `@page-agent/page-controller` 的 `showMask`/`hideMask` 签名。
+- 改无障碍树 / 序列化 / 工具协议。
+- 改呼吸灯视觉或光标 SVG。
+
+## 用户故事与验收标准
+
+1. 作为宿主，我在初始化阶段调用无参 `handle.showMask()`，只看到呼吸灯、看不到鼠标。
+   - 验收：无参 `showMask()` → `simulatorMask.show({ showCursor: false })`（`cursorMode: 'actionOnly'` 默认）。
+2. 作为用户，遮罩刚变为 visible 时，光标节点已是 `display: none`，不会闪在左上角。
+   - 验收：`#createCursor()` 后、以及 `show()` 未传 / `showCursor: false` 时，`.webmcp-page-agent-cursor` 的 `style.display === 'none'`。
+3. 作为用户，click/fill/select/hover 执行完毕后，若遮罩仍开着，光标应收起，只留呼吸灯。
+   - 验收：`executePageAgentTool` 的 `finally` 在 `shown === true` 且非 `always` 时再调 `show({ showCursor: false })`。
+4. 作为集成方，我可以设 `cursorMode: 'never'` 让任何路径都不出光标；设 `'always'` 则遮罩期间保持光标。
+   - 验收：配置读写经 `get/setPageAgentToolConfig`；调度层按策略解析 `showCursor`。
+5. 作为宿主，我仍可显式 `showMask({ showCursor: true })` 强制出光标（`never` 除外，全局关闭优先）。
+
+## 非功能要求
+
+- 无参 `showMask()` 的调用方无需改代码即可获得「仅呼吸灯」行为（默认值修正，有意不向后兼容旧的「无参即出光标」）。
+- 新增可选参数与 `cursorMode` 字段，不删除既有配置项。
+
+## 完成定义
+
+- [x] `design.md` / `tasks.md` 已齐
+- [x] 对应自动化测试已在 `tasks.md` 列出并实现（含中文「复现：」）
+- [x] `docs/webmcp-sdk/page-agent-tool.md` 与 `skills/page-agent/SKILL.md` 已更新
+- [x] `pnpm -F @opentiny/next-sdk test` 与 `pnpm -F @opentiny/next-sdk build` 通过

--- a/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/requirements.md
@@ -61,11 +61,11 @@
    - 验收：无参 `showMask()` → `simulatorMask.show({ showCursor: false })`（`cursorMode: 'actionOnly'` 默认）。
 2. 作为用户，遮罩刚变为 visible 时，光标节点已是 `display: none`，不会闪在左上角。
    - 验收：`#createCursor()` 后、以及 `show()` 未传 / `showCursor: false` 时，`.webmcp-page-agent-cursor` 的 `style.display === 'none'`。
-3. 作为用户，click/fill/select/hover 执行完毕后，若遮罩仍开着，光标应收起，只留呼吸灯。
+3. 作为用户，click/fill/select/hover 执行完毕后，若遮罩仍开着且 `cursorMode !== 'always'`，光标应收起，只留呼吸灯。
    - 验收：`executePageAgentTool` 的 `finally` 在 `shown === true` 且非 `always` 时再调 `show({ showCursor: false })`。
-4. 作为集成方，我可以设 `cursorMode: 'never'` 让任何路径都不出光标；设 `'always'` 则遮罩期间保持光标。
+4. 作为集成方，我可以设 `cursorMode: 'never'` 让任何路径都不出光标；设 `'always'` 则未传 `showCursor` 时遮罩期间保持光标。
    - 验收：配置读写经 `get/setPageAgentToolConfig`；调度层按策略解析 `showCursor`。
-5. 作为宿主，我仍可显式 `showMask({ showCursor: true })` 强制出光标（`never` 除外，全局关闭优先）。
+5. 作为宿主，我仍可显式 `showMask({ showCursor: true })` 强制出光标（`never` 除外，全局关闭优先）；`always` 下仍可用 `showMask({ showCursor: false })` 临时隐藏。
 
 ## 非功能要求
 

--- a/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/tasks.md
@@ -1,0 +1,47 @@
+# Tasks：遮罩接管态与光标生命周期分离
+
+每个任务应可独立验收；涉及行为变更的任务 **必须** 含测试子项。
+
+## 任务列表
+
+- [x] Task 1：改造 `SimulatorMask` 默认值与初始样式
+  - 输入：`packages/next-sdk/page-tools/page-agent-mask/SimulatorMask.ts`
+  - 产物：`#createCursor()` 设 `display: 'none'`；`show()` 默认 `showCursor: false`
+  - [x] 测试：`packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts`
+    - 复现：构造后、未 `show` 前光标已是 `display: none`
+    - 复现：无参 `show()` 不显示光标
+    - 保留：`show({ showCursor: false })` 后再 `show({ showCursor: true })` 能恢复显示
+
+- [x] Task 2：`PageAgentToolConfig` 增加 `cursorMode`
+  - 输入：`packages/next-sdk/page-tools/tool-config.ts`
+  - 产物：类型、默认值 `'actionOnly'`、`get/set` / `resolvePatch` 透传
+  - [x] 测试：`packages/next-sdk/test/page-tools/tool-config.test.ts`
+
+- [x] Task 3：句柄透传 + 调度层收光标 + `cursorMode` 解析
+  - 输入：依赖 Task 1、Task 2；`packages/next-sdk/page-tools/page-agent-tool.ts`
+  - 产物：
+    - `PageAgentToolHandle.showMask(options?)` 直调 `simulatorMask.show`
+    - 操作类开始时 `resolveShowCursor('pointer')`；感知类 `observe`
+    - `finally` 在遮罩仍显示且非 `always` 时收光标
+  - [x] 测试：`packages/next-sdk/test/page-tools/page-agent-tool.test.ts`（句柄无参/有参）
+  - [x] 测试：`packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts`
+    - 复现：操作类结束后再次 `show({ showCursor: false })`
+    - `cursorMode: 'never' | 'always'` 行为
+
+- [x] Task 4：用户文档与 Skill
+  - 产物：`docs/webmcp-sdk/page-agent-tool.md`、`packages/next-sdk/skills/page-agent/SKILL.md`、`packages/next-sdk/specs/README.md`
+
+- [x] Task 5：验收命令通过
+  - 命令：`pnpm -F @opentiny/next-sdk test`（221 passed）
+  - 命令：`pnpm -F @opentiny/next-sdk build`
+
+## 依赖顺序
+
+1 → 2 → 3 → 4 → 5
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+pnpm -F @opentiny/next-sdk build
+```

--- a/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
@@ -36,8 +36,12 @@ const mockSimulatorMaskSetCursorPosition = vi.fn()
 
 vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
   SimulatorMask: class SimulatorMask {
-    show(options?: { showCursor?: boolean }) { mockSimulatorMaskShow(options) }
-    hide() {}
+    shown = false
+    show(options?: { showCursor?: boolean }) {
+      this.shown = true
+      mockSimulatorMaskShow(options)
+    }
+    hide() { this.shown = false }
     dispose() {}
     borderElement() {}
     removeBorderElement() {}
@@ -87,6 +91,7 @@ vi.mock('../../page-tools/handlers/clipboard', () => ({
 
 import { registerPageAgentTool } from '../../page-tools/page-agent-tool'
 import type { PageAgentToolInput } from '../../page-tools/schema'
+import { setPageAgentToolConfig } from '../../page-tools/tool-config'
 
 interface ToolTextContent {
   type: string
@@ -213,6 +218,7 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
     }
     mockSimulatorMaskShow.mockClear()
     mockSimulatorMaskSetCursorPosition.mockClear()
+    setPageAgentToolConfig({ cursorMode: 'actionOnly' })
   })
 
   afterAll(() => {
@@ -255,6 +261,15 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
       }
     )
 
+    it.each(fullMaskActions)(
+      '复现：操作类 action=%s 完成后光标仍停留 —— 前置遮罩保持开启；步骤执行操作；期望 finally 再调 show({ showCursor: false })',
+      async (action) => {
+        await execute(argsFor(action))
+        expect(mockSimulatorMaskShow).toHaveBeenLastCalledWith({ showCursor: false })
+        expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: true })
+      }
+    )
+
     it('复现：hover 操作应在调用 handler 前更新鼠标位置到目标元素中心', async () => {
       await execute(argsFor('browserState'))
 
@@ -275,9 +290,25 @@ describe('page-agent-tool action dispatch（防 switch fall-through）', () => {
       expect(setCursorOrder).toBeLessThan(handleHoverOrder)
     })
 
-    it('复现：clipboard 操作不展示 SimulatorMask —— 步骤执行 clipboard；期望 show 未被调用', async () => {
+    it('复现：clipboard 操作不展示 SimulatorMask —— 步骤执行 clipboard；期望不会以 showCursor: true 打开光标', async () => {
       await execute(argsFor('clipboard'))
-      expect(mockSimulatorMaskShow).not.toHaveBeenCalled()
+      expect(mockSimulatorMaskShow).not.toHaveBeenCalledWith({ showCursor: true })
+    })
+
+    it('cursorMode=never 时操作类也不展示光标', async () => {
+      setPageAgentToolConfig({ cursorMode: 'never' })
+      await execute(argsFor('click'))
+      expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: false })
+      expect(mockSimulatorMaskShow).not.toHaveBeenCalledWith({ showCursor: true })
+      setPageAgentToolConfig({ cursorMode: 'actionOnly' })
+    })
+
+    it('cursorMode=always 时感知类也展示光标，且结束后不收起', async () => {
+      setPageAgentToolConfig({ cursorMode: 'always' })
+      await execute(argsFor('browserState'))
+      expect(mockSimulatorMaskShow).toHaveBeenCalledWith({ showCursor: true })
+      expect(mockSimulatorMaskShow).toHaveBeenLastCalledWith({ showCursor: true })
+      setPageAgentToolConfig({ cursorMode: 'actionOnly' })
     })
   })
 })

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -163,6 +163,18 @@ describe('registerPageAgentTool - mask 显隐句柄', () => {
     expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: false })
   })
 
+  it('cursorMode=always 时显式 showCursor: false 仍可临时隐藏光标', async () => {
+    const handle = registerPageAgentTool({ cursorMode: 'always' })
+    await handle.showMask({ showCursor: false })
+    expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: false })
+  })
+
+  it('cursorMode=always 时无参 showMask 默认展示光标', async () => {
+    const handle = registerPageAgentTool({ cursorMode: 'always' })
+    await handle.showMask()
+    expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: true })
+  })
+
   it('复现：WXT 聊天结束后呼吸灯与箭头未关闭 —— 前置 registerPageAgentTool 且已 showMask；步骤 dispatch page-agent-chat-end；期望 hideMask 被调用', async () => {
     const handle = registerPageAgentTool()
     await handle.showMask()

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -5,10 +5,13 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 const maskSpies = vi.hoisted(() => ({ show: vi.fn(), hide: vi.fn() }))
 vi.mock('../../page-tools/page-agent-mask/SimulatorMask', () => ({
   SimulatorMask: class SimulatorMask {
-    show() {
-      maskSpies.show()
+    shown = false
+    show(options?: { showCursor?: boolean }) {
+      this.shown = true
+      maskSpies.show(options)
     }
     hide() {
+      this.shown = false
       maskSpies.hide()
     }
     dispose() {}
@@ -140,6 +143,24 @@ describe('registerPageAgentTool - mask 显隐句柄', () => {
 
     await handle.hideMask()
     expect(maskSpies.hide).toHaveBeenCalledTimes(1)
+  })
+
+  it('复现：准备中就显示鼠标 —— 前置 registerPageAgentTool；步骤 无参 handle.showMask()；期望内部 show({ showCursor: false }) 仅呼吸灯', async () => {
+    const handle = registerPageAgentTool()
+    await handle.showMask()
+    expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: false })
+  })
+
+  it('复现：宿主无法声明只要呼吸灯 —— 步骤 handle.showMask({ showCursor: true })；期望透传到 SimulatorMask.show', async () => {
+    const handle = registerPageAgentTool()
+    await handle.showMask({ showCursor: true })
+    expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: true })
+  })
+
+  it('handle.showMask() 在 cursorMode=never 时忽略显式 showCursor: true', async () => {
+    const handle = registerPageAgentTool({ cursorMode: 'never' })
+    await handle.showMask({ showCursor: true })
+    expect(maskSpies.show).toHaveBeenCalledWith({ showCursor: false })
   })
 
   it('复现：WXT 聊天结束后呼吸灯与箭头未关闭 —— 前置 registerPageAgentTool 且已 showMask；步骤 dispatch page-agent-chat-end；期望 hideMask 被调用', async () => {

--- a/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
+++ b/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
@@ -15,6 +15,21 @@ describe('SimulatorMask 鼠标指针显隐与连续切换逻辑', () => {
     vi.restoreAllMocks()
   })
 
+  it('复现：准备中遮罩刚 visible 时光标闪在左上角 —— 前置 new SimulatorMask()；步骤 未调用 show；期望 #cursor 的 style.display 已是 none', () => {
+    mask = new SimulatorMask()
+    const cursorEl = mask.wrapper.querySelector('.webmcp-page-agent-cursor') as HTMLElement
+    expect(cursorEl).not.toBeNull()
+    expect(cursorEl.style.display).toBe('none')
+  })
+
+  it('复现：宿主无参 show() 不应露出鼠标 —— 步骤 mask.show()；期望 #cursor display 仍为 none', () => {
+    mask = new SimulatorMask()
+    mask.show()
+    const cursorEl = mask.wrapper.querySelector('.webmcp-page-agent-cursor') as HTMLElement
+    expect(mask.shown).toBe(true)
+    expect(cursorEl.style.display).toBe('none')
+  })
+
   it('复现：先执行 browserState(无鼠标) 再执行 click(有鼠标) 时鼠标箭头未出现的 Bug —— 步骤 1. show({ showCursor: false })；步骤 2. 连续 show({ showCursor: true })；期望 #cursor 的 style.display 被恢复为 ""', () => {
     mask = new SimulatorMask()
 
@@ -30,13 +45,6 @@ describe('SimulatorMask 鼠标指针显隐与连续切换逻辑', () => {
     mask.show({ showCursor: true })
 
     // 期望：cursorEl 的 display 应当恢复为空字符串（即显示鼠标）
-    expect(cursorEl.style.display).toBe('')
-  })
-
-  it('默认为 showCursor: true 时，鼠标样式为 display: ""', () => {
-    mask = new SimulatorMask()
-    mask.show()
-    const cursorEl = mask.wrapper.querySelector('.webmcp-page-agent-cursor') as HTMLElement
     expect(cursorEl.style.display).toBe('')
   })
 })

--- a/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
+++ b/packages/next-sdk/test/page-tools/simulator-mask-cursor.test.ts
@@ -30,7 +30,7 @@ describe('SimulatorMask 鼠标指针显隐与连续切换逻辑', () => {
     expect(cursorEl.style.display).toBe('none')
   })
 
-  it('复现：先执行 browserState(无鼠标) 再执行 click(有鼠标) 时鼠标箭头未出现的 Bug —— 步骤 1. show({ showCursor: false })；步骤 2. 连续 show({ showCursor: true })；期望 #cursor 的 style.display 被恢复为 ""', () => {
+  it('复现：先执行 browserState(无鼠标) 再执行 click(有鼠标) 时鼠标箭头未出现的 Bug —— 步骤 1. show({ showCursor: false })；步骤 2. 连续 show({ showCursor: true })；期望 #cursor 的 style.display 被恢复为 "block"', () => {
     mask = new SimulatorMask()
 
     // 1. 模拟执行 browserState: show({ showCursor: false })
@@ -44,7 +44,7 @@ describe('SimulatorMask 鼠标指针显隐与连续切换逻辑', () => {
     // 2. 遮罩处于 shown=true 状态下，模拟执行 click/fill: show({ showCursor: true })
     mask.show({ showCursor: true })
 
-    // 期望：cursorEl 的 display 应当恢复为空字符串（即显示鼠标）
-    expect(cursorEl.style.display).toBe('')
+    // 期望：cursorEl 的 display 应当恢复为 "block"（即显示鼠标）
+    expect(cursorEl.style.display).toBe('block')
   })
 })

--- a/packages/next-sdk/test/page-tools/tool-config.test.ts
+++ b/packages/next-sdk/test/page-tools/tool-config.test.ts
@@ -57,6 +57,17 @@ describe('getPageAgentToolConfig / setPageAgentToolConfig', () => {
     const next = setPageAgentToolConfig({ enableHighlight: false })
     expect(getPageAgentToolConfig()).toEqual(next)
   })
+
+  it('未初始化时 cursorMode 默认为 actionOnly', () => {
+    expect(getPageAgentToolConfig().cursorMode).toBe('actionOnly')
+    expect(DEFAULT_PAGE_AGENT_TOOL_CONFIG.cursorMode).toBe('actionOnly')
+  })
+
+  it('merge 模式下可覆盖 cursorMode，未传入字段保持原值', () => {
+    setPageAgentToolConfig({ cursorMode: 'never' })
+    expect(getPageAgentToolConfig().cursorMode).toBe('never')
+    expect(getPageAgentToolConfig().enableHighlight).toBe(false)
+  })
 })
 
 describe('setPageAgentToolConfig - a11yConfig 子字段', () => {

--- a/packages/next-sdk/test/page-tools/tool-config.test.ts
+++ b/packages/next-sdk/test/page-tools/tool-config.test.ts
@@ -68,6 +68,14 @@ describe('getPageAgentToolConfig / setPageAgentToolConfig', () => {
     expect(getPageAgentToolConfig().cursorMode).toBe('never')
     expect(getPageAgentToolConfig().enableHighlight).toBe(false)
   })
+
+  it('复现：函数式 patch 只改其它字段时 cursorMode 被重置为 actionOnly —— 前置 cursorMode=never；步骤函数式只改 enableHighlight；期望 cursorMode 仍为 never', () => {
+    setPageAgentToolConfig({ cursorMode: 'never', enableHighlight: false })
+    const next = setPageAgentToolConfig((current) => ({ enableHighlight: !current.enableHighlight }))
+    expect(next.enableHighlight).toBe(true)
+    expect(next.cursorMode).toBe('never')
+    expect(getPageAgentToolConfig().cursorMode).toBe('never')
+  })
 })
 
 describe('setPageAgentToolConfig - a11yConfig 子字段', () => {
@@ -106,6 +114,18 @@ describe('setPageAgentToolConfig - a11yConfig 子字段', () => {
     const result = getPageAgentToolConfig().a11yConfig
     expect(result.roles.some((r) => r.role === 'tab')).toBe(false)
     expect(result.roles.some((r) => r.role === 'keep-me')).toBe(true)
+  })
+
+  it('函数式 patch 过滤 a11y 规则时，未返回的 cursorMode 仍保持原值', () => {
+    setPageAgentToolConfig({
+      cursorMode: 'always',
+      a11yConfig: { roles: [{ role: 'tab', selector: '.tab-1' }] }
+    })
+    setPageAgentToolConfig((current) => ({
+      a11yConfig: { roles: current.a11yConfig.roles.filter((r) => r.role !== 'tab') }
+    }))
+    expect(getPageAgentToolConfig().cursorMode).toBe('always')
+    expect(getPageAgentToolConfig().a11yConfig.roles.some((r) => r.role === 'tab')).toBe(false)
   })
 
   it('replace 模式丢弃之前的运行期状态，只与默认值重新合并', () => {


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

- 把「遮罩（呼吸灯锁屏）」和「AI 鼠标光标」拆成两套生命周期：接管 Tab / 思考中默认只出呼吸灯，避免准备阶段就露出鼠标。
- `PageAgentToolHandle.showMask()` 可透传 `{ showCursor?: boolean }`；新增运行期 `cursorMode`（`actionOnly` | `always` | `never`）。
- 操作类 action（click/fill/select/hover）结束后，若遮罩仍开着且非 `always`，自动收起光标。
- Spec：`packages/next-sdk/specs/REQ-20260903-mask-cursor-lifecycle/`

## What is the current behavior?

宿主（Sidepanel / 子 Agent）在 lockTask 时调用无参 `handle.showMask()`，内部落到 `SimulatorMask.show()` 的默认值 `showCursor: true`，准备中/思考中就会把光标露出来。叠加另外两处断层：

1. 光标 DOM 创建时未设 `display: none`，遮罩一 visible，箭头会闪在 `(0, 0)`。
2. 操作类步骤的 `finally` 只撤红框、不收光标；宿主保持遮罩期间，鼠标会停在上次点击位置。

根因是前序 `REQ-20260810` 为「向后兼容」把默认值写成了 `true`：开遮罩被当成「正在鼠标操作」，但接管态只需要锁屏防误触。

## What is the new behavior?

- 无参 `show()` / `showMask()` 默认只出呼吸灯（`showCursor: false`）；光标节点初始即为 `display: none`。
- 宿主可 `showMask({ showCursor: true })` 强制出光标。
- `cursorMode` 默认 `actionOnly`：仅操作类步骤出光标，结束后收起；`always` 未传参时遮罩可见即出光标（显式 `showCursor: false` 仍可临时隐藏）；`never` 全局关闭（覆盖显式 `showCursor: true`）。
- 函数式 `setPageAgentToolConfig` 只改其它字段时，不会把已设置的 `cursorMode` 重置回默认值。

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

有意不兼容：原先无参 `showMask()` 会同时露出鼠标。需要光标的调用方改为显式 `{ showCursor: true }`，或设置 `cursorMode: 'always'`。这是本需求的修复目标（接管态 ≠ 正在鼠标操作）。

## Other information

口头 / 架构评审需求，无强制关联 Issue。验证：`pnpm -F @opentiny/next-sdk test`。