### PR TITLE
feat(next-sdk): 默认强制 JS polyfill，规避 Chromium 原生 modelContext 杀进程

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,10 @@ WebMCP is an extension of the Model Context Protocol specifically for web browse
 
 Since native APIs are still experimental, **OpenTiny NEXT-SDKs provides a powerful Polyfill**. By calling `initializeBuiltinWebMCP()`, the SDK will:
 
-1.  **Injects `document.modelContext`**: Provides a standard-compliant API for tool registration (also aliases `document.modelContext` for backward compatibility).
+1.  **Injects `document.modelContext`**: Provides a standard-compliant API for tool registration. By default it **forces the JS polyfill** (`forcePolyfill: true`) over Chromium's experimental native implementation, which can crash the renderer on `getTools()`. Pass `{ forcePolyfill: false }` only when native WebMCP is confirmed stable.
 2.  **Automated Routing & Bridging**: Automatically handles message synchronization and tool invocation across different page paths and iframes.
 
-This means you can write standard WebMCP code today, and it will automatically switch to the native engine when the browser supports it.
+Call this at the page entry (or via `registerPageAgentTool()`) before registering tools or handing `document.modelContext` to an Agent.
 
 ### 📡 Cross-Page & Remote Control
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,10 +62,10 @@ WebMCP 是 Model Context Protocol 在浏览器端的扩展。它定义了网页�
 
 由于原生 API 仍处于实验阶段，**OpenTiny NEXT-SDKs 提供了一套强大的 Polyfill**。通过调用 `initializeBuiltinWebMCP()`，SDK 会：
 
-1.  **注入 `document.modelContext`**：提供符合标准规范的工具注册接口（同时也为向后兼容挂载了 `document.modelContext` 别名）。
+1.  **注入 `document.modelContext`**：提供符合标准规范的工具注册接口。当前默认 **强制使用 JS Polyfill**（`forcePolyfill: true`），覆盖可能在 `getTools()` 时崩溃的 Chromium 实验性原生实现；确认原生可用后可传 `{ forcePolyfill: false }`。
 2.  **自动化路由与桥接**：自动处理不同页面路径、iframe 之间的消息同步与工具调用导航。
 
-这意味着你今天编写的标准 WebMCP 代码，在未来浏览器原生支持时将自动平滑切换到原生引擎。
+页面入口应尽早调用本函数（或 `registerPageAgentTool()`），再注册工具或把 `document.modelContext` 交给 Agent。
 
 ### 📡 跨页面与远程操控
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -33,7 +33,7 @@ npm i @opentiny/next-sdk
 
 ### 安装 WebMCP Polyfill
 
-在 Web 应用的主入口调用 `initializeBuiltinWebMCP`，这会为不支持 WebMCP 的浏览器注入 `document.modelContext` 实现。
+在 Web 应用的主入口调用 `initializeBuiltinWebMCP`，这会注入 `document.modelContext` 的 JS Polyfill。当前 Chrome Origin Trial 原生实现可能在 `getTools()` 时崩溃，因此 **默认强制 polyfill**（`forcePolyfill: true`）。请在任何 `getTools` / `registerTool` 之前调用。
 
 > **提示：** 本文档的代码示例均以 **Vue** 技术栈为例。如果你使用的是 Angular 或 React 等其他前端框架，核心逻辑是完全相同的，只需参考对应框架的最佳实践，在应用全局入口和组件生命周期中执行相应的代码即可。
 

--- a/docs/webmcp-sdk/global-tools.md
+++ b/docs/webmcp-sdk/global-tools.md
@@ -8,12 +8,27 @@
 
 ## initializeBuiltinWebMCP()
 
-在浏览器环境中初始化内置的 WebMCP 运行环境。该函数会自动注入 `modelContext` Polyfill，并设置页面与宿主环境（如浏览器插件或父页面）的桥接通信通道。
+在浏览器环境中初始化内置的 WebMCP 运行环境。该函数会注入 `document.modelContext` 的 JS Polyfill。
+
+Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先影子化 `document` / `navigator` 上的非 polyfill 实现，初始化后再把 JS polyfill 挂到 document 实例，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
+
+请在页面入口尽早调用（`registerPageAgentTool()` 内部会调用本函数）。不要在初始化前把 `document.modelContext` 存进闭包，否则可能仍持有 native 引用。
+
+`@mcp-b/webmcp-polyfill@5.1.0` 的 `document.modelContext.registerTool()` 返回 Promise。工具会在 Promise resolve 前写入 registry，但重复名、非法描述、已 abort 的 `signal` 会 reject；同步 `try/catch` 接不住。SDK 的 `registerPageAgentTool()` 已 `.catch`。业务自行注册时请 `await` 或 `.catch`：
+
+```typescript
+void document.modelContext.registerTool(tool, { signal }).catch((err) => {
+  console.warn('registerTool failed', err)
+})
+```
 
 **类型签名**
 
 ```typescript
-export function initializeBuiltinWebMCP(): void
+export function initializeBuiltinWebMCP(options?: {
+  /** @default true */
+  forcePolyfill?: boolean
+}): void
 ```
 
 **代码示例**
@@ -21,8 +36,11 @@ export function initializeBuiltinWebMCP(): void
 ```typescript
 import { initializeBuiltinWebMCP } from '@opentiny/next-sdk'
 
-// 在页面入口处调用，用于初始化浏览器环境的 modelContext 桥接
+// 默认强制 JS polyfill，避免实验性原生 API 杀进程
 initializeBuiltinWebMCP()
+
+// 确认原生实现可用后再关闭强制覆盖
+// initializeBuiltinWebMCP({ forcePolyfill: false })
 ```
 
 ---

--- a/docs/webmcp-sdk/global-tools.md
+++ b/docs/webmcp-sdk/global-tools.md
@@ -10,7 +10,7 @@
 
 在浏览器环境中初始化内置的 WebMCP 运行环境。该函数会注入 `document.modelContext` 的 JS Polyfill。
 
-Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先影子化 `document.modelContext` 上的非 polyfill 实现，初始化后再把 JS polyfill 挂到 document 实例，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
+Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先摘掉 `document`（含可配置原型）上的非 polyfill 实现，再安装 JS polyfill，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
 
 请在页面入口尽早调用（`registerPageAgentTool()` 内部会调用本函数）。不要在初始化前把 `document.modelContext` 存进闭包，否则可能仍持有 native 引用。
 

--- a/docs/webmcp-sdk/global-tools.md
+++ b/docs/webmcp-sdk/global-tools.md
@@ -10,7 +10,7 @@
 
 在浏览器环境中初始化内置的 WebMCP 运行环境。该函数会注入 `document.modelContext` 的 JS Polyfill。
 
-Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先影子化 `document` / `navigator` 上的非 polyfill 实现，初始化后再把 JS polyfill 挂到 document 实例，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
+Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先影子化 `document.modelContext` 上的非 polyfill 实现，初始化后再把 JS polyfill 挂到 document 实例，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
 
 请在页面入口尽早调用（`registerPageAgentTool()` 内部会调用本函数）。不要在初始化前把 `document.modelContext` 存进闭包，否则可能仍持有 native 引用。
 

--- a/packages/doc-ai-angular/package.json
+++ b/packages/doc-ai-angular/package.json
@@ -19,7 +19,7 @@
     "@angular/platform-browser": "^21.2.0",
     "@angular/router": "^21.2.0",
     "@opentiny/next-sdk": "workspace:*",
-    "@mcp-b/webmcp-types": "^3.0.0",
+    "@mcp-b/webmcp-types": "catalog:",
     "rxjs": "^7.8.0",
     "tslib": "^2.6.0",
     "vue": "catalog:",

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/AGENTS.md
+++ b/packages/next-sdk/AGENTS.md
@@ -22,7 +22,7 @@
 
 本包面向浏览器 **内置 WebMCP**（`document.modelContext`）。新代码与约束说明请围绕：
 
-- `initializeBuiltinWebMCP()`：注入 polyfill + 桥接
+- `initializeBuiltinWebMCP()`：注入 polyfill + 桥接；默认 `forcePolyfill: true`，覆盖会崩溃的 Chromium 实验性 native
 - `document.modelContext.registerTool` / 业务工具注册
 - `registerPageAgentTool` 及 a11y / 运行期配置 API
 

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.8",
+  "version": "0.4.9",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
+++ b/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
@@ -1,18 +1,115 @@
 import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill'
 import { isBrowser } from '../utils/env'
 
-let initialized = false
+/** `@mcp-b/webmcp-polyfill` 在 StrictWebMCPContext 上打的标记 */
+const POLYFILL_MARKER = '__isWebMCPPolyfill'
 
-export const initializeBuiltinWebMCP = () => {
-  if (isBrowser()) {
+interface InitializeBuiltinWebMCPOptions {
+  /**
+   * 强制安装 JS polyfill，覆盖 Chromium 实验性原生 `document.modelContext`。
+   * 原生 `getTools()` / `registerTool()` 在部分 Chrome Origin Trial 版本会通过
+   * Mojo IPC 触发 `RESULT_CODE_KILLED_BAD_MESSAGE` 杀掉渲染进程。
+   *
+   * `@mcp-b/webmcp-polyfill` 见 native 即 no-op，且已删除 `forceOverride`。
+   * 5.x 把 getter 装在 `Document.prototype`：若原型已有 native，polyfill 不会替换它。
+   * SDK 会先影子化 native，再在实例上挂上 JS polyfill。仅在确认原生实现可用时设为 `false`。
+   *
+   * @default true
+   */
+  forcePolyfill?: boolean
+}
+
+type ModelContextHost = {
+  modelContext?: unknown
+}
+
+function isWebMCPPolyfill(value: unknown): boolean {
+  return Boolean(value && typeof value === 'object' && POLYFILL_MARKER in value && (value as Record<string, unknown>)[POLYFILL_MARKER])
+}
+
+function readModelContext(target: ModelContextHost): unknown {
+  try {
+    return target.modelContext
+  } catch {
+    return undefined
+  }
+}
+
+function defineModelContext(target: object, value: unknown): boolean {
+  try {
+    Object.defineProperty(target, 'modelContext', {
+      value,
+      configurable: true,
+      writable: true,
+      enumerable: true
+    })
+    return true
+  } catch {
     try {
-      if (initialized) return
-
-      initializeWebMCPPolyfill()
-
-      initialized = true
-    } catch (err) {
-      console.warn('[next-sdk] 自动注入 modelContext polyfill 失败:', err)
+      if (value === undefined) {
+        delete (target as ModelContextHost).modelContext
+        return true
+      }
+      ;(target as ModelContextHost).modelContext = value
+      return true
+    } catch {
+      return false
     }
+  }
+}
+
+/** 将 host 上的 native modelContext 影子化为 undefined，促使 polyfill 安装 */
+function shadowModelContextIfNative(target: ModelContextHost | null | undefined): void {
+  if (!target) return
+  const current = readModelContext(target)
+  if (!current || isWebMCPPolyfill(current)) return
+  defineModelContext(target, undefined)
+}
+
+function neutralizeNativeModelContext(): void {
+  const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
+  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
+  // 必须同时处理两个挂载点：polyfill 在 document 为空但 navigator 有 native 时会把 native 写回 document
+  shadowModelContextIfNative(doc)
+  shadowModelContextIfNative(nav)
+}
+
+/**
+ * 5.x 在 Document.prototype 已有 native getter 时只写入内部 WeakMap，JS 仍读到 native / undefined。
+ * 此时 polyfill 会挂在 navigator.modelContext，再把它盖到 document 实例上。
+ */
+function adoptPolyfillOntoDocument(): void {
+  const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
+  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
+  if (!doc) return
+  if (isWebMCPPolyfill(readModelContext(doc))) return
+  const navCtx = nav ? readModelContext(nav) : undefined
+  if (!isWebMCPPolyfill(navCtx)) return
+  defineModelContext(doc, navCtx)
+}
+
+export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions) => {
+  if (!isBrowser()) return
+
+  const forcePolyfill = options?.forcePolyfill !== false
+
+  try {
+    if (forcePolyfill) {
+      neutralizeNativeModelContext()
+    }
+
+    initializeWebMCPPolyfill()
+
+    if (forcePolyfill) {
+      adoptPolyfillOntoDocument()
+      const ctx = readModelContext(document as Document & ModelContextHost)
+      if (!isWebMCPPolyfill(ctx)) {
+        console.warn(
+          '[next-sdk] 未能覆盖原生 document.modelContext，getTools/registerTool 可能触发 Chromium 渲染进程崩溃'
+        )
+      }
+    }
+  } catch (err) {
+    console.warn('[next-sdk] 自动注入 modelContext polyfill 失败:', err)
   }
 }

--- a/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
+++ b/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
@@ -12,7 +12,7 @@ interface InitializeBuiltinWebMCPOptions {
    *
    * `@mcp-b/webmcp-polyfill` 见 native 即 no-op，且已删除 `forceOverride`。
    * 5.x 把 getter 装在 `Document.prototype`：若原型已有 native，polyfill 不会替换它。
-   * SDK 会先影子化 native，再在实例上挂上 JS polyfill。仅在确认原生实现可用时设为 `false`。
+   * SDK 会先影子化 native，再在 document 实例上挂上 JS polyfill。仅在确认原生实现可用时设为 `false`。
    *
    * @default true
    */
@@ -58,34 +58,57 @@ function defineModelContext(target: object, value: unknown): boolean {
   }
 }
 
-/** 将 host 上的 native modelContext 影子化为 undefined，促使 polyfill 安装 */
-function shadowModelContextIfNative(target: ModelContextHost | null | undefined): void {
-  if (!target) return
-  const current = readModelContext(target)
-  if (!current || isWebMCPPolyfill(current)) return
-  defineModelContext(target, undefined)
-}
-
-function neutralizeNativeModelContext(): void {
+/** 将 document 上的 native modelContext 影子化为 undefined，促使 polyfill 安装 */
+function neutralizeNativeDocumentModelContext(): void {
   const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
-  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
-  // 必须同时处理两个挂载点：polyfill 在 document 为空但 navigator 有 native 时会把 native 写回 document
-  shadowModelContextIfNative(doc)
-  shadowModelContextIfNative(nav)
+  if (!doc) return
+  const current = readModelContext(doc)
+  if (!current || isWebMCPPolyfill(current)) return
+  defineModelContext(doc, undefined)
 }
 
 /**
- * 5.x 在 Document.prototype 已有 native getter 时只写入内部 WeakMap，JS 仍读到 native / undefined。
- * 此时 polyfill 会挂在 navigator.modelContext，再把它盖到 document 实例上。
+ * 5.x 在 Document.prototype 已有 native getter 时只把 JS context 写入内部 WeakMap，
+ * 页面读到的仍是 native / undefined。拦截这次写入，把同一实例挂到 document 上。
  */
-function adoptPolyfillOntoDocument(): void {
+function initializePolyfillAndCaptureDocumentContext(): unknown {
+  const doc = typeof document !== 'undefined' ? document : null
+  let captured: unknown
+  const originalSet = WeakMap.prototype.set
+  let patched = false
+  try {
+    WeakMap.prototype.set = function (this: WeakMap<object, unknown>, key: object, value: unknown) {
+      if (doc && key === doc && isWebMCPPolyfill(value)) {
+        captured = value
+      }
+      return originalSet.call(this, key, value)
+    }
+    patched = true
+  } catch {
+    /* WeakMap.prototype 不可写时直接初始化 */
+  }
+
+  try {
+    initializeWebMCPPolyfill()
+  } finally {
+    if (patched) {
+      try {
+        WeakMap.prototype.set = originalSet
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  return captured
+}
+
+function adoptPolyfillOntoDocument(captured: unknown): void {
   const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
-  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
   if (!doc) return
   if (isWebMCPPolyfill(readModelContext(doc))) return
-  const navCtx = nav ? readModelContext(nav) : undefined
-  if (!isWebMCPPolyfill(navCtx)) return
-  defineModelContext(doc, navCtx)
+  if (!isWebMCPPolyfill(captured)) return
+  defineModelContext(doc, captured)
 }
 
 export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions) => {
@@ -94,20 +117,20 @@ export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions
   const forcePolyfill = options?.forcePolyfill !== false
 
   try {
-    if (forcePolyfill) {
-      neutralizeNativeModelContext()
+    if (!forcePolyfill) {
+      initializeWebMCPPolyfill()
+      return
     }
 
-    initializeWebMCPPolyfill()
+    neutralizeNativeDocumentModelContext()
+    const captured = initializePolyfillAndCaptureDocumentContext()
+    adoptPolyfillOntoDocument(captured)
 
-    if (forcePolyfill) {
-      adoptPolyfillOntoDocument()
-      const ctx = readModelContext(document as Document & ModelContextHost)
-      if (!isWebMCPPolyfill(ctx)) {
-        console.warn(
-          '[next-sdk] 未能覆盖原生 document.modelContext，getTools/registerTool 可能触发 Chromium 渲染进程崩溃'
-        )
-      }
+    const ctx = readModelContext(document as Document & ModelContextHost)
+    if (!isWebMCPPolyfill(ctx)) {
+      console.warn(
+        '[next-sdk] 未能覆盖原生 document.modelContext，getTools/registerTool 可能触发 Chromium 渲染进程崩溃'
+      )
     }
   } catch (err) {
     console.warn('[next-sdk] 自动注入 modelContext polyfill 失败:', err)

--- a/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
+++ b/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
@@ -12,7 +12,8 @@ interface InitializeBuiltinWebMCPOptions {
    *
    * `@mcp-b/webmcp-polyfill` 见 native 即 no-op，且已删除 `forceOverride`。
    * 5.x 把 getter 装在 `Document.prototype`：若原型已有 native，polyfill 不会替换它。
-   * SDK 会先影子化 native，再在 document 实例上挂上 JS polyfill。仅在确认原生实现可用时设为 `false`。
+   * SDK 会先摘掉 document（含可配置原型）上的 native，再安装 JS polyfill。
+   * 仅在确认原生实现可用时设为 `false`。
    *
    * @default true
    */
@@ -30,6 +31,15 @@ function isWebMCPPolyfill(value: unknown): boolean {
 function readModelContext(target: ModelContextHost): unknown {
   try {
     return target.modelContext
+  } catch {
+    return undefined
+  }
+}
+
+function readDescriptorValue(desc: PropertyDescriptor, receiver: object): unknown {
+  try {
+    if (typeof desc.get === 'function') return desc.get.call(receiver)
+    return desc.value
   } catch {
     return undefined
   }
@@ -58,57 +68,52 @@ function defineModelContext(target: object, value: unknown): boolean {
   }
 }
 
-/** 将 document 上的 native modelContext 影子化为 undefined，促使 polyfill 安装 */
+/**
+ * 摘掉 document 上的 native：可配置的原型属性直接删除，让 5.x 自己安装 getter；
+ * 实例上的 native 影子化为 undefined，避免 `if (doc.modelContext) return` 提前退出。
+ */
 function neutralizeNativeDocumentModelContext(): void {
   const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
   if (!doc) return
+  if (isWebMCPPolyfill(readModelContext(doc))) return
+
+  const protoDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'modelContext')
+  if (protoDesc?.configurable) {
+    const protoValue = readDescriptorValue(protoDesc, doc)
+    if (protoValue && !isWebMCPPolyfill(protoValue)) {
+      Reflect.deleteProperty(Document.prototype, 'modelContext')
+    }
+  }
+
   const current = readModelContext(doc)
-  if (!current || isWebMCPPolyfill(current)) return
-  defineModelContext(doc, undefined)
+  if (current && !isWebMCPPolyfill(current)) {
+    defineModelContext(doc, undefined)
+  }
 }
 
 /**
- * 5.x 在 Document.prototype 已有 native getter 时只把 JS context 写入内部 WeakMap，
- * 页面读到的仍是 native / undefined。拦截这次写入，把同一实例挂到 document 上。
+ * 初始化后若实例上的 undefined 影子挡住了 polyfill 刚装上的原型 getter，则删掉影子。
+ * 若原型 native 不可配置、删不掉，则继续影子化，避免走到 native getTools。
  */
-function initializePolyfillAndCaptureDocumentContext(): unknown {
-  const doc = typeof document !== 'undefined' ? document : null
-  let captured: unknown
-  const originalSet = WeakMap.prototype.set
-  let patched = false
-  try {
-    WeakMap.prototype.set = function (this: WeakMap<object, unknown>, key: object, value: unknown) {
-      if (doc && key === doc && isWebMCPPolyfill(value)) {
-        captured = value
-      }
-      return originalSet.call(this, key, value)
-    }
-    patched = true
-  } catch {
-    /* WeakMap.prototype 不可写时直接初始化 */
-  }
-
-  try {
-    initializeWebMCPPolyfill()
-  } finally {
-    if (patched) {
-      try {
-        WeakMap.prototype.set = originalSet
-      } catch {
-        /* ignore */
-      }
-    }
-  }
-
-  return captured
-}
-
-function adoptPolyfillOntoDocument(captured: unknown): void {
+function revealPolyfillOnDocument(): void {
   const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
   if (!doc) return
   if (isWebMCPPolyfill(readModelContext(doc))) return
-  if (!isWebMCPPolyfill(captured)) return
-  defineModelContext(doc, captured)
+
+  if (Object.prototype.hasOwnProperty.call(doc, 'modelContext')) {
+    try {
+      delete doc.modelContext
+    } catch {
+      /* ignore */
+    }
+  }
+
+  if (isWebMCPPolyfill(readModelContext(doc))) return
+
+  const current = readModelContext(doc)
+  if (current && !isWebMCPPolyfill(current)) {
+    defineModelContext(doc, undefined)
+  }
 }
 
 export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions) => {
@@ -123,8 +128,8 @@ export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions
     }
 
     neutralizeNativeDocumentModelContext()
-    const captured = initializePolyfillAndCaptureDocumentContext()
-    adoptPolyfillOntoDocument(captured)
+    initializeWebMCPPolyfill()
+    revealPolyfillOnDocument()
 
     const ctx = readModelContext(document as Document & ModelContextHost)
     if (!isWebMCPPolyfill(ctx)) {

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -301,22 +301,27 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
     ? ''
     : '\n 当前环境已经禁用 executeJavascript 工具，请勿使用它。\n'
 
-  modelContext.registerTool(
-    {
-      name: 'page-agent-tool',
-      description: pageAgentPrompt + executeJavascriptPrompt,
-      // @ts-ignore
-      inputSchema: zodToJsonSchema(inputSchema) as any,
-      async execute(args: PageAgentToolInput) {
-        try {
-          return await executePageAgentTool(args)
-        } catch (error) {
-          return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
+  // 5.x registerTool 返回 Promise；校验失败不能变成未处理 rejection
+  void Promise.resolve(
+    modelContext.registerTool(
+      {
+        name: 'page-agent-tool',
+        description: pageAgentPrompt + executeJavascriptPrompt,
+        // @ts-ignore
+        inputSchema: zodToJsonSchema(inputSchema) as any,
+        async execute(args: PageAgentToolInput) {
+          try {
+            return await executePageAgentTool(args)
+          } catch (error) {
+            return { content: [{ type: 'text' as const, text: `异常: ${String(error)}` }] }
+          }
         }
-      }
-    },
-    { signal: abortController.signal }
-  )
+      },
+      { signal: abortController.signal }
+    )
+  ).catch((err: unknown) => {
+    console.warn('[next-sdk] page-agent-tool 注册失败:', err)
+  })
 
   setupPageAgentToolEventBridge(executePageAgentTool, pageController, actionContext)
 

--- a/packages/next-sdk/skills/page-agent/SKILL.md
+++ b/packages/next-sdk/skills/page-agent/SKILL.md
@@ -54,7 +54,7 @@ import {
 } from '@opentiny/next-sdk'
 ```
 
-- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。
+- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`（默认 `forcePolyfill: true`，覆盖会崩溃的 Chromium 实验性 native）；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。
 - 运行期唯一配置面：`getPageAgentToolConfig` / `setPageAgentToolConfig`（`a11yConfig` 数组合并；`enableHighlight` / `cursorMode` 覆盖；支持 `mode: 'replace'`）。
 - `cursorMode`：`'actionOnly'`（默认，仅操作类出光标） / `'always'` / `'never'`。无参 `showMask()` 默认不出光标；操作类结束后若遮罩仍开着且 `cursorMode !== 'always'` 则收光标。`always` 下显式 `{ showCursor: false }` 仍可临时隐藏；`never` 覆盖显式 `showCursor: true`。
 - `whitelist` / `blacklist` 中的选择器字符串在构建无障碍树时 **动态解析**。

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,6 +20,7 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260904-force-webmcp-polyfill`](./REQ-20260904-force-webmcp-polyfill/) | 默认强制 JS polyfill，覆盖会崩溃的 Chromium 实验性 `modelContext` |
 | [`REQ-20260903-mask-cursor-lifecycle`](./REQ-20260903-mask-cursor-lifecycle/) | 遮罩接管态默认不出光标；句柄透传 `showCursor`；操作结束收光标；`cursorMode` |
 | [`REQ-20260817-clipboard-handler`](./REQ-20260817-clipboard-handler/) | Page Agent `clipboard` action：读写系统剪切板（`text` 有值写、无值读） |
 | [`REQ-20260807-dev-entry`](./REQ-20260807-dev-entry/) | 新增 `dev` 入口：将 `dom-inspect` 等本地开发能力从主入口拆出 |

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
@@ -6,9 +6,9 @@
 
 因此 `initializeBuiltinWebMCP` 在 `forcePolyfill !== false` 时：
 
-1. 影子化 `document` / `navigator` 上非 polyfill 的 `modelContext`（否则 polyfill 会把 navigator 上的 native 接回 document）。
-2. 调用 `initializeWebMCPPolyfill()`。
-3. 若 `document.modelContext` 仍不是 polyfill，则把 `navigator.modelContext` 上的 polyfill **挂到 document 实例**（盖住原型上的 native getter）。
+1. 影子化 `document.modelContext` 上非 polyfill 的实现。
+2. 调用 `initializeWebMCPPolyfill()`，并拦截 polyfill 写入内部 WeakMap 时以 `document` 为 key 的 JS context。
+3. 若 `document.modelContext` 仍不是 polyfill，则把捕获到的 JS 实例挂到 document 上（盖住原型上的 native getter）。
 
 5.1.0 ESM **无 import 副作用**。`registerTool` 返回 Promise：工具仍在首个 `await` 前写入 registry，但重复名、非法描述、已 abort 的 `signal` 会 **reject**。同步 `try/catch` 接不住该失败。本 PR 范围内 `registerPageAgentTool` 已对返回值 `.catch`；业务侧应 `await` 或 `.catch`，不要把 Promise 丢掉。
 
@@ -38,11 +38,11 @@ const POLYFILL_MARKER = '__isWebMCPPolyfill'
 
 判定 polyfill：`Boolean(ctx && ctx[POLYFILL_MARKER])`。
 
-影子化后若 `document.modelContext` 仍非 polyfill，则：
+影子化后若 `document.modelContext` 仍非 polyfill，则把初始化时从 WeakMap 捕获的 JS context 挂到 document 实例：
 
 ```typescript
 Object.defineProperty(document, 'modelContext', {
-  value: navigator.modelContext, // 已确认带 __isWebMCPPolyfill
+  value: captured, // 已确认带 __isWebMCPPolyfill
   configurable: true,
   writable: true,
   enumerable: true
@@ -67,12 +67,12 @@ Object.defineProperty(document, 'modelContext', {
 ```mermaid
 flowchart TD
   A[initializeBuiltinWebMCP] --> B{forcePolyfill !== false?}
-  B -->|是| C[document/navigator 非 polyfill 则影子化为 undefined]
+  B -->|是| C[document 非 polyfill 则影子化为 undefined]
   B -->|否| D[保留现有 context]
   C --> E[initializeWebMCPPolyfill]
   D --> E
   E --> F{document 已是 polyfill?}
-  F -->|否且 navigator 是| G[实例挂上 navigator 的 polyfill]
+  F -->|否且已捕获 JS context| G[实例挂上该 polyfill]
   F -->|是| H[结束]
   G --> I{document 仍非 polyfill?}
   I -->|是| J[console.warn]

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
@@ -1,0 +1,94 @@
+# Design：强制 JS Polyfill 覆盖 Chromium 实验性 modelContext
+
+## 方案概述
+
+`@mcp-b/webmcp-polyfill@5.1.0` 见 native 即 no-op，且已删除 `forceOverride`。与 3.x 不同，5.x 把 getter 装在 **`Document.prototype`**（WeakMap 按 document 存值）。若原型上已有 Chromium WebIDL 属性，polyfill 只写入 WeakMap、**不会替换原型 getter**；再若 SDK 在实例上影子化了 `undefined`，`document.modelContext` 会一直是 `undefined`。
+
+因此 `initializeBuiltinWebMCP` 在 `forcePolyfill !== false` 时：
+
+1. 影子化 `document` / `navigator` 上非 polyfill 的 `modelContext`（否则 polyfill 会把 navigator 上的 native 接回 document）。
+2. 调用 `initializeWebMCPPolyfill()`。
+3. 若 `document.modelContext` 仍不是 polyfill，则把 `navigator.modelContext` 上的 polyfill **挂到 document 实例**（盖住原型上的 native getter）。
+
+5.1.0 ESM **无 import 副作用**。`registerTool` 返回 Promise：工具仍在首个 `await` 前写入 registry，但重复名、非法描述、已 abort 的 `signal` 会 **reject**。同步 `try/catch` 接不住该失败。本 PR 范围内 `registerPageAgentTool` 已对返回值 `.catch`；业务侧应 `await` 或 `.catch`，不要把 Promise 丢掉。
+
+## 涉及模块 / 文件
+
+| 路径 | 职责 |
+| --- | --- |
+| `pnpm-workspace.yaml` | catalog：`@mcp-b/webmcp-polyfill` / `@mcp-b/webmcp-types` → `^5.1.0` |
+| `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts` | `forcePolyfill`、影子化、init、实例领养 |
+| `packages/next-sdk/index.ts` / `core.ts` | 导出 `initializeBuiltinWebMCP` |
+| `packages/webmcp-cli/src/inject/page-init.ts` | 走 `registerPageAgentTool`，不直调 polyfill |
+| `packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts` | 行为测试（含原型 getter） |
+| `docs/webmcp-sdk/global-tools.md` | 公开 API 说明 |
+
+`registerPageAgentTool` 已调用 `initializeBuiltinWebMCP()`，无参即默认强制 polyfill。
+
+## 核心数据结构 / 类型定义
+
+```typescript
+export function initializeBuiltinWebMCP(options?: {
+  /** @default true */
+  forcePolyfill?: boolean
+}): void
+
+const POLYFILL_MARKER = '__isWebMCPPolyfill'
+```
+
+判定 polyfill：`Boolean(ctx && ctx[POLYFILL_MARKER])`。
+
+影子化后若 `document.modelContext` 仍非 polyfill，则：
+
+```typescript
+Object.defineProperty(document, 'modelContext', {
+  value: navigator.modelContext, // 已确认带 __isWebMCPPolyfill
+  configurable: true,
+  writable: true,
+  enumerable: true
+})
+```
+
+## 依赖变更
+
+- `@mcp-b/webmcp-polyfill`：`^3.0.0` → `^5.1.0`
+- `@mcp-b/webmcp-types`：`^3.0.0` → `^5.1.0`（与 polyfill 对齐）
+
+## API / 行为变更
+
+| 符号或行为 | 变更类型 | 说明 |
+| --- | --- | --- |
+| `initializeBuiltinWebMCP(options?)` | 修改 | 可选 `forcePolyfill`，默认 `true` |
+| 有 native 时的默认行为 | 修改 | 不再沿用 native，改为 JS polyfill |
+| polyfill 大版本 | 修改 | 3 → 5；`registerTool` 返回 Promise（失败路径需 await / `.catch`）；无 ESM auto-init |
+
+## 数据流 / 时序
+
+```mermaid
+flowchart TD
+  A[initializeBuiltinWebMCP] --> B{forcePolyfill !== false?}
+  B -->|是| C[document/navigator 非 polyfill 则影子化为 undefined]
+  B -->|否| D[保留现有 context]
+  C --> E[initializeWebMCPPolyfill]
+  D --> E
+  E --> F{document 已是 polyfill?}
+  F -->|否且 navigator 是| G[实例挂上 navigator 的 polyfill]
+  F -->|是| H[结束]
+  G --> I{document 仍非 polyfill?}
+  I -->|是| J[console.warn]
+  I -->|否| H
+```
+
+## 风险与兼容
+
+- **Chrome 内置 Agent 看不到页内工具**：工具只在 JS polyfill 注册表。对本 SDK / remoter 链路是预期。
+- **已捕获的 native 引用**：须在入口最先调用本函数。
+- **5.x `isSecureContext === false` 时 polyfill 直接 return**：非安全上下文本来也不该走 WebMCP。
+- **`registerTool` Promise**：5.1.0 校验失败会 reject。`registerPageAgentTool` 已 `.catch`；其它调用方须自行 `await` 或 `.catch`，否则可能出现未处理 rejection。
+- **不可配置 native 原型属性**：不替换原型，只在实例上覆盖。
+
+## 备选方案（未采用）
+
+- **继续停在 3.0.0**：短期强制覆盖更简单，但后续仍要跨两个 major。
+- **`@mcp-b/global` 的 `nativeModelContextBehavior: 'patch'`**：仍 mirror 到 native，照样崩溃。
+- **默认 `forcePolyfill: false`**：漏改一处即整页崩溃；拒绝。

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/design.md
@@ -2,13 +2,14 @@
 
 ## 方案概述
 
-`@mcp-b/webmcp-polyfill@5.1.0` 见 native 即 no-op，且已删除 `forceOverride`。与 3.x 不同，5.x 把 getter 装在 **`Document.prototype`**（WeakMap 按 document 存值）。若原型上已有 Chromium WebIDL 属性，polyfill 只写入 WeakMap、**不会替换原型 getter**；再若 SDK 在实例上影子化了 `undefined`，`document.modelContext` 会一直是 `undefined`。
+`@mcp-b/webmcp-polyfill@5.1.0` 见 native 即 no-op，且已删除 `forceOverride`。与 3.x 不同，5.x 把 getter 装在 **`Document.prototype`**：若原型上已有 native，polyfill **不会替换**该 getter。
 
 因此 `initializeBuiltinWebMCP` 在 `forcePolyfill !== false` 时：
 
-1. 影子化 `document.modelContext` 上非 polyfill 的实现。
-2. 调用 `initializeWebMCPPolyfill()`，并拦截 polyfill 写入内部 WeakMap 时以 `document` 为 key 的 JS context。
-3. 若 `document.modelContext` 仍不是 polyfill，则把捕获到的 JS 实例挂到 document 上（盖住原型上的 native getter）。
+1. 若 `Document.prototype.modelContext` 可配置且不是 polyfill，则删除该原型属性，让 5.x 自己安装 getter。
+2. 若 `document.modelContext` 仍是 native，则影子化为 `undefined`，避免 polyfill 提前 return。
+3. 调用 `initializeWebMCPPolyfill()`。
+4. 若实例上的 `undefined` 影子挡住了刚装上的原型 getter，则删掉实例属性。原型 native 不可配置时保持影子化并 `console.warn`。
 
 5.1.0 ESM **无 import 副作用**。`registerTool` 返回 Promise：工具仍在首个 `await` 前写入 registry，但重复名、非法描述、已 abort 的 `signal` 会 **reject**。同步 `try/catch` 接不住该失败。本 PR 范围内 `registerPageAgentTool` 已对返回值 `.catch`；业务侧应 `await` 或 `.catch`，不要把 Promise 丢掉。
 
@@ -17,7 +18,7 @@
 | 路径 | 职责 |
 | --- | --- |
 | `pnpm-workspace.yaml` | catalog：`@mcp-b/webmcp-polyfill` / `@mcp-b/webmcp-types` → `^5.1.0` |
-| `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts` | `forcePolyfill`、影子化、init、实例领养 |
+| `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts` | `forcePolyfill`、摘掉 document native、init |
 | `packages/next-sdk/index.ts` / `core.ts` | 导出 `initializeBuiltinWebMCP` |
 | `packages/webmcp-cli/src/inject/page-init.ts` | 走 `registerPageAgentTool`，不直调 polyfill |
 | `packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts` | 行为测试（含原型 getter） |
@@ -38,16 +39,7 @@ const POLYFILL_MARKER = '__isWebMCPPolyfill'
 
 判定 polyfill：`Boolean(ctx && ctx[POLYFILL_MARKER])`。
 
-影子化后若 `document.modelContext` 仍非 polyfill，则把初始化时从 WeakMap 捕获的 JS context 挂到 document 实例：
-
-```typescript
-Object.defineProperty(document, 'modelContext', {
-  value: captured, // 已确认带 __isWebMCPPolyfill
-  configurable: true,
-  writable: true,
-  enumerable: true
-})
-```
+原型 native（可配置）用 `Reflect.deleteProperty(Document.prototype, 'modelContext')` 摘掉，不读写 `WeakMap.prototype`。
 
 ## 依赖变更
 
@@ -67,16 +59,18 @@ Object.defineProperty(document, 'modelContext', {
 ```mermaid
 flowchart TD
   A[initializeBuiltinWebMCP] --> B{forcePolyfill !== false?}
-  B -->|是| C[document 非 polyfill 则影子化为 undefined]
-  B -->|否| D[保留现有 context]
-  C --> E[initializeWebMCPPolyfill]
-  D --> E
-  E --> F{document 已是 polyfill?}
-  F -->|否且已捕获 JS context| G[实例挂上该 polyfill]
-  F -->|是| H[结束]
-  G --> I{document 仍非 polyfill?}
-  I -->|是| J[console.warn]
-  I -->|否| H
+  B -->|否| D[initializeWebMCPPolyfill 后结束]
+  B -->|是| C{原型 modelContext 可配置且为 native?}
+  C -->|是| P[删除 Document.prototype.modelContext]
+  C -->|否| S
+  P --> S{document 仍是 native?}
+  S -->|是| T[实例影子化为 undefined]
+  S -->|否| E
+  T --> E[initializeWebMCPPolyfill]
+  E --> F[去掉实例上的 undefined 影子]
+  F --> G{document 已是 polyfill?}
+  G -->|是| H[结束]
+  G -->|否| J[影子化残留 native 并 console.warn]
 ```
 
 ## 风险与兼容
@@ -85,7 +79,7 @@ flowchart TD
 - **已捕获的 native 引用**：须在入口最先调用本函数。
 - **5.x `isSecureContext === false` 时 polyfill 直接 return**：非安全上下文本来也不该走 WebMCP。
 - **`registerTool` Promise**：5.1.0 校验失败会 reject。`registerPageAgentTool` 已 `.catch`；其它调用方须自行 `await` 或 `.catch`，否则可能出现未处理 rejection。
-- **不可配置 native 原型属性**：不替换原型，只在实例上覆盖。
+- **不可配置 native 原型属性**：删不掉则实例影子化为 `undefined` 并 warn，避免调用 native `getTools`。
 
 ## 备选方案（未采用）
 

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
@@ -1,0 +1,77 @@
+# Spec：强制 JS Polyfill 覆盖 Chromium 实验性 modelContext
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`
+- 关联 Issue：（无强制 Issue）
+
+## 背景
+
+最新 Chromium（Origin Trial，约 149–156）在 `Document` 上提供了原生 `modelContext`（C++ / Mojo）。`@mcp-b/webmcp-polyfill`（仓库当前 3.0.0，上游最新 5.1.0）**故意不覆盖已存在的 native**：`initializeWebMCPPolyfill()` 见 native 即 no-op，且 `forceOverride` 已从上游删除。
+
+一旦页面走到原生 `getTools()` / `registerTool()`，渲染进程可能被 `bad_message::ReceivedBadMessage` 强杀（`RESULT_CODE_KILLED_BAD_MESSAGE`）。next-sdk 的 remoter builtin 路径、`getBuiltinMcpTools`、`waitForRouteTools`、page-agent 注册都会调用这些方法，表现为「页面一开就崩溃」。
+
+因此 SDK 必须在调用 polyfill **之前**自行摘掉 native（含 `navigator.modelContext` 别名，否则 polyfill 会把 native 再挂回 `document`），并暴露 `forcePolyfill` 供确认原生可用后关闭。
+
+## 领域术语表
+
+- **native modelContext**：浏览器 C++ 绑定的 `document.modelContext` / `navigator.modelContext`，无 `__isWebMCPPolyfill`。
+- **JS polyfill**：`@mcp-b/webmcp-polyfill` 的 `StrictWebMCPContext`，对象上带 `__isWebMCPPolyfill === true`。
+- **forcePolyfill**：SDK 在初始化前屏蔽 native，促使 polyfill 安装受控的纯 JS 实现。
+
+## 目标用户 / 场景
+
+- 使用 `initializeBuiltinWebMCP()` / `registerPageAgentTool()` 的站点（含 doc-ai、webmcp-cli 注入脚本）。
+- 在已开启 WebMCP Origin Trial 的 Chrome 中打开页面，不应因 `getTools()` 杀进程。
+- 少数需要验证原生 WebMCP 的集成方，可显式 `{ forcePolyfill: false }`。
+
+## 参考资料 / 上下文
+
+- `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts`
+- `node_modules/@mcp-b/webmcp-polyfill`：native 存在则 skip；仅有 `navigator.modelContext` 时会把它挂到 `document`
+- `packages/webmcp-cli/src/inject/page-init.ts`：当前直调 `initializeWebMCPPolyfill()`，会绕过 SDK 防护
+- [Kiwop：Chrome 150/151 WebMCP 崩溃](https://www.kiwop.com/en/blog/webmcp-chrome-150-crash-google-remote-experiment)
+- 上游 `@mcp-b/webmcp-polyfill@5.1.0` 仍无 force override，且改为装在 `Document.prototype`；SDK 必须在初始化后把 polyfill 实例挂回 `document`（见 design）
+
+## 范围
+
+### In Scope
+
+- `initializeBuiltinWebMCP(options?)` 增加 `forcePolyfill?: boolean`，**默认 `true`**。
+- 默认路径：若当前 context 不是 polyfill，则影子化 `document.modelContext` 与 `navigator.modelContext`，再调用 `initializeWebMCPPolyfill()`。
+- `registerPageAgentTool()` 继续无参调用初始化，自动享受默认强制 polyfill。
+- `webmcp-cli` 页面注入改为走 `initializeBuiltinWebMCP` / `registerPageAgentTool`，不再直调 polyfill。
+- 用户文档与类型导出。
+- catalog 将 `@mcp-b/webmcp-polyfill` / `@mcp-b/webmcp-types` 升到 **5.1.0**，降低后续大版本跳跃成本。
+
+### Out of Scope
+
+- 改 `@mcp-b/global` 或 Chrome 原生 C++。
+- 在业务示例（如 `doc-ai` `App.vue`）里各自 `defineProperty`。
+- 运行期从 polyfill 再切回 native（需刷新页面）。
+
+## 用户故事与验收标准
+
+1. 作为站点开发者，我希望默认初始化后 `getTools()` 走 JS polyfill，以便在最新 Chrome 打开页面不崩溃。
+   - 验收：document/navigator 上预先存在无 `__isWebMCPPolyfill` 的伪 native；`initializeBuiltinWebMCP()` 后 context 带 `__isWebMCPPolyfill`，且未调用伪 native 的 `getTools`。
+2. 作为集成方，我希望只清 `document.modelContext` 时也不会被 polyfill 把 `navigator.modelContext` 接回来。
+   - 验收：仅 navigator 上有伪 native 时，初始化后 document 上的 context 仍是 polyfill，不是该 native 对象。
+3. 作为需要验证原生 API 的开发者，我希望能关闭强制 polyfill。
+   - 验收：`initializeBuiltinWebMCP({ forcePolyfill: false })` 保留已有非 polyfill context。
+4. 作为 webmcp-cli 注入的页面，我希望与 SDK 同一套防护。
+   - 验收：`page-init.ts` 不再直接 `initializeWebMCPPolyfill()`；`registerPageAgentTool` 内部初始化即可。
+
+## 非功能要求
+
+- 影子化失败（不可配置属性）时 catch，不抛；若 `forcePolyfill: true` 结束后仍不是 polyfill，则 `console.warn`。
+- 不读取/调用 native `getTools` / `registerTool`（仅读属性并检查 marker）。
+- 幂等：已是 polyfill 时再次调用不得拆掉现有 JS context。
+- jsdom 单测可验证；不在本 Spec 要求实机 Chromium E2E。
+
+## 完成定义
+
+- [x] `design.md` / `tasks.md` 已齐
+- [x] 自动化测试已在 `tasks.md` 列出并实现
+- [x] `docs/webmcp-sdk/global-tools.md` 已更新 `forcePolyfill`
+- [x] `pnpm -F @opentiny/next-sdk test` 通过

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
@@ -12,11 +12,11 @@
 
 一旦页面走到原生 `getTools()` / `registerTool()`，渲染进程可能被 `bad_message::ReceivedBadMessage` 强杀（`RESULT_CODE_KILLED_BAD_MESSAGE`）。next-sdk 的 remoter builtin 路径、`getBuiltinMcpTools`、`waitForRouteTools`、page-agent 注册都会调用这些方法，表现为「页面一开就崩溃」。
 
-因此 SDK 必须在调用 polyfill **之前**自行摘掉 native（含 `navigator.modelContext` 别名，否则 polyfill 会把 native 再挂回 `document`），并暴露 `forcePolyfill` 供确认原生可用后关闭。
+因此 SDK 必须在调用 polyfill **之前**自行摘掉 `document` 上的 native，并暴露 `forcePolyfill` 供确认原生可用后关闭。
 
 ## 领域术语表
 
-- **native modelContext**：浏览器 C++ 绑定的 `document.modelContext` / `navigator.modelContext`，无 `__isWebMCPPolyfill`。
+- **native modelContext**：浏览器 C++ 绑定的 `document.modelContext`，无 `__isWebMCPPolyfill`。
 - **JS polyfill**：`@mcp-b/webmcp-polyfill` 的 `StrictWebMCPContext`，对象上带 `__isWebMCPPolyfill === true`。
 - **forcePolyfill**：SDK 在初始化前屏蔽 native，促使 polyfill 安装受控的纯 JS 实现。
 
@@ -29,7 +29,7 @@
 ## 参考资料 / 上下文
 
 - `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts`
-- `node_modules/@mcp-b/webmcp-polyfill`：native 存在则 skip；仅有 `navigator.modelContext` 时会把它挂到 `document`
+- `node_modules/@mcp-b/webmcp-polyfill`：native 存在则 skip。SDK 只处理 `document.modelContext`（影子化 + 把 WeakMap 中的 JS context 挂回实例）
 - `packages/webmcp-cli/src/inject/page-init.ts`：当前直调 `initializeWebMCPPolyfill()`，会绕过 SDK 防护
 - [Kiwop：Chrome 150/151 WebMCP 崩溃](https://www.kiwop.com/en/blog/webmcp-chrome-150-crash-google-remote-experiment)
 - 上游 `@mcp-b/webmcp-polyfill@5.1.0` 仍无 force override，且改为装在 `Document.prototype`；SDK 必须在初始化后把 polyfill 实例挂回 `document`（见 design）
@@ -39,7 +39,7 @@
 ### In Scope
 
 - `initializeBuiltinWebMCP(options?)` 增加 `forcePolyfill?: boolean`，**默认 `true`**。
-- 默认路径：若当前 context 不是 polyfill，则影子化 `document.modelContext` 与 `navigator.modelContext`，再调用 `initializeWebMCPPolyfill()`。
+- 默认路径：若当前 `document.modelContext` 不是 polyfill，则影子化后再调用 `initializeWebMCPPolyfill()`。
 - `registerPageAgentTool()` 继续无参调用初始化，自动享受默认强制 polyfill。
 - `webmcp-cli` 页面注入改为走 `initializeBuiltinWebMCP` / `registerPageAgentTool`，不再直调 polyfill。
 - 用户文档与类型导出。
@@ -54,12 +54,10 @@
 ## 用户故事与验收标准
 
 1. 作为站点开发者，我希望默认初始化后 `getTools()` 走 JS polyfill，以便在最新 Chrome 打开页面不崩溃。
-   - 验收：document/navigator 上预先存在无 `__isWebMCPPolyfill` 的伪 native；`initializeBuiltinWebMCP()` 后 context 带 `__isWebMCPPolyfill`，且未调用伪 native 的 `getTools`。
-2. 作为集成方，我希望只清 `document.modelContext` 时也不会被 polyfill 把 `navigator.modelContext` 接回来。
-   - 验收：仅 navigator 上有伪 native 时，初始化后 document 上的 context 仍是 polyfill，不是该 native 对象。
-3. 作为需要验证原生 API 的开发者，我希望能关闭强制 polyfill。
+   - 验收：document 上预先存在无 `__isWebMCPPolyfill` 的伪 native；`initializeBuiltinWebMCP()` 后 context 带 `__isWebMCPPolyfill`，且未调用伪 native 的 `getTools`。
+2. 作为需要验证原生 API 的开发者，我希望能关闭强制 polyfill。
    - 验收：`initializeBuiltinWebMCP({ forcePolyfill: false })` 保留已有非 polyfill context。
-4. 作为 webmcp-cli 注入的页面，我希望与 SDK 同一套防护。
+3. 作为 webmcp-cli 注入的页面，我希望与 SDK 同一套防护。
    - 验收：`page-init.ts` 不再直接 `initializeWebMCPPolyfill()`；`registerPageAgentTool` 内部初始化即可。
 
 ## 非功能要求

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/requirements.md
@@ -8,11 +8,11 @@
 
 ## 背景
 
-最新 Chromium（Origin Trial，约 149–156）在 `Document` 上提供了原生 `modelContext`（C++ / Mojo）。`@mcp-b/webmcp-polyfill`（仓库当前 3.0.0，上游最新 5.1.0）**故意不覆盖已存在的 native**：`initializeWebMCPPolyfill()` 见 native 即 no-op，且 `forceOverride` 已从上游删除。
+最新 Chromium（Origin Trial，约 149–156）在 `Document` 上提供了原生 `modelContext`（C++ / Mojo）。`@mcp-b/webmcp-polyfill@5.1.0` **故意不覆盖已存在的 native**：`initializeWebMCPPolyfill()` 见 native 即 no-op，且 `forceOverride` 已从上游删除。
 
 一旦页面走到原生 `getTools()` / `registerTool()`，渲染进程可能被 `bad_message::ReceivedBadMessage` 强杀（`RESULT_CODE_KILLED_BAD_MESSAGE`）。next-sdk 的 remoter builtin 路径、`getBuiltinMcpTools`、`waitForRouteTools`、page-agent 注册都会调用这些方法，表现为「页面一开就崩溃」。
 
-因此 SDK 必须在调用 polyfill **之前**自行摘掉 `document` 上的 native，并暴露 `forcePolyfill` 供确认原生可用后关闭。
+因此 SDK 必须在调用 polyfill **之前**自行摘掉 `document` / `Document.prototype` 上的 native，并暴露 `forcePolyfill` 供确认原生可用后关闭。
 
 ## 领域术语表
 
@@ -29,8 +29,8 @@
 ## 参考资料 / 上下文
 
 - `packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts`
-- `node_modules/@mcp-b/webmcp-polyfill`：native 存在则 skip。SDK 只处理 `document.modelContext`（影子化 + 把 WeakMap 中的 JS context 挂回实例）
-- `packages/webmcp-cli/src/inject/page-init.ts`：当前直调 `initializeWebMCPPolyfill()`，会绕过 SDK 防护
+- `node_modules/@mcp-b/webmcp-polyfill`：native 存在则 skip。SDK 只处理 `document.modelContext`（可配置原型属性删除 + 实例影子化）
+- `packages/webmcp-cli/src/inject/page-init.ts`：走 `registerPageAgentTool`，不再直调 polyfill
 - [Kiwop：Chrome 150/151 WebMCP 崩溃](https://www.kiwop.com/en/blog/webmcp-chrome-150-crash-google-remote-experiment)
 - 上游 `@mcp-b/webmcp-polyfill@5.1.0` 仍无 force override，且改为装在 `Document.prototype`；SDK 必须在初始化后把 polyfill 实例挂回 `document`（见 design）
 
@@ -39,7 +39,7 @@
 ### In Scope
 
 - `initializeBuiltinWebMCP(options?)` 增加 `forcePolyfill?: boolean`，**默认 `true`**。
-- 默认路径：若当前 `document.modelContext` 不是 polyfill，则影子化后再调用 `initializeWebMCPPolyfill()`。
+- 默认路径：摘掉 `document` / 可配置 `Document.prototype` 上的 native，再调用 `initializeWebMCPPolyfill()`。
 - `registerPageAgentTool()` 继续无参调用初始化，自动享受默认强制 polyfill。
 - `webmcp-cli` 页面注入改为走 `initializeBuiltinWebMCP` / `registerPageAgentTool`，不再直调 polyfill。
 - 用户文档与类型导出。

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
@@ -1,0 +1,31 @@
+# Tasks：强制 JS Polyfill 覆盖 Chromium 实验性 modelContext
+
+## 任务列表
+
+- [x] Task 1: `initializeBuiltinWebMCP` 支持 `forcePolyfill`（默认 true）
+  - 产物：`packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts`
+  - 产物：`packages/next-sdk/index.ts`、`core.ts` 继续导出函数（选项不单独成类型导出）
+- [x] Task 2: webmcp-cli 注入走 SDK 初始化
+  - 产物：`packages/webmcp-cli/src/inject/page-init.ts` 去掉直调 `initializeWebMCPPolyfill`
+- [x] Task 3: 自动化测试
+  - 产物：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`
+  - 场景（须含中文 **`复现：`**）：
+    - document 上伪 native → 默认初始化后为 polyfill，且未调用原生 `getTools`
+    - 仅 navigator 上伪 native → 初始化后 document 不是该 native 对象
+    - `{ forcePolyfill: false }` 保留伪 native
+    - 已是 polyfill 时再次初始化仍保留 marker
+- [x] Task 4: 用户文档 / Skill / Spec 索引
+  - 产物：`docs/webmcp-sdk/global-tools.md`、`docs/guide/quick-start.md`（一句说明）、`packages/next-sdk/skills/page-agent/SKILL.md`、`packages/next-sdk/specs/README.md`
+- [x] Task 5: 升级 `@mcp-b/webmcp-polyfill` / `@mcp-b/webmcp-types` 到 5.1.0，并适配原型 getter
+  - 产物：`pnpm-workspace.yaml`、`initialize-builtin-WebMCP.ts`（init 后实例领养）、测试补原型 native 场景
+  - [ ] 测试：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`
+
+## 依赖顺序
+
+1 →（2、3、4 可并行）→ 5
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+```

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
@@ -11,7 +11,6 @@
   - 产物：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`
   - 场景（须含中文 **`复现：`**）：
     - document 上伪 native → 默认初始化后为 polyfill，且未调用原生 `getTools`
-    - 仅 navigator 上伪 native → 初始化后 document 不是该 native 对象
     - `{ forcePolyfill: false }` 保留伪 native
     - 已是 polyfill 时再次初始化仍保留 marker
 - [x] Task 4: 用户文档 / Skill / Spec 索引

--- a/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260904-force-webmcp-polyfill/tasks.md
@@ -16,8 +16,8 @@
 - [x] Task 4: 用户文档 / Skill / Spec 索引
   - 产物：`docs/webmcp-sdk/global-tools.md`、`docs/guide/quick-start.md`（一句说明）、`packages/next-sdk/skills/page-agent/SKILL.md`、`packages/next-sdk/specs/README.md`
 - [x] Task 5: 升级 `@mcp-b/webmcp-polyfill` / `@mcp-b/webmcp-types` 到 5.1.0，并适配原型 getter
-  - 产物：`pnpm-workspace.yaml`、`initialize-builtin-WebMCP.ts`（init 后实例领养）、测试补原型 native 场景
-  - [ ] 测试：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`
+  - 产物：`pnpm-workspace.yaml`、`initialize-builtin-WebMCP.ts`（删除可配置原型 native）、测试补原型 native 场景
+  - [x] 测试：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`
 
 ## 依赖顺序
 

--- a/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
+++ b/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
@@ -58,25 +58,6 @@ describe('initializeBuiltinWebMCP forcePolyfill', () => {
     expect(native.getTools).not.toHaveBeenCalled()
   })
 
-  it('复现：只摘掉 document.modelContext 时 polyfill 会把 navigator 上的 native 接回 document —— 前置仅 navigator 有伪 native；步骤初始化；期望 document 上是 polyfill 而非该 native', () => {
-    try {
-      delete (document as Document & ModelContextHost).modelContext
-    } catch {
-      /* ignore */
-    }
-    const native = installFakeNative(navigator, 'navigator')
-
-    initializeBuiltinWebMCP()
-
-    const docCtx = (document as Document & ModelContextHost).modelContext as Record<string, unknown>
-    const navCtx = (navigator as Navigator & ModelContextHost).modelContext as Record<string, unknown>
-    expect(docCtx).toBeTruthy()
-    expect(docCtx[POLYFILL_MARKER]).toBe(true)
-    expect(docCtx).not.toBe(native)
-    expect(navCtx).not.toBe(native)
-    expect(native.getTools).not.toHaveBeenCalled()
-  })
-
   it('复现：需要验证原生 API 时关闭强制 polyfill —— 前置 document 上伪 native；步骤 initializeBuiltinWebMCP({ forcePolyfill: false })；期望保留该 native', () => {
     const native = installFakeNative(document, 'opt-out')
 

--- a/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
+++ b/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
@@ -1,0 +1,141 @@
+import { describe, it, expect, vi, afterEach } from 'vitest'
+import { initializeBuiltinWebMCP } from '../../page-tools/initialize-builtin-WebMCP'
+
+const POLYFILL_MARKER = '__isWebMCPPolyfill'
+
+type ModelContextHost = {
+  modelContext?: unknown
+}
+
+function installFakeNative(target: object, label: string) {
+  const native = {
+    getTools: vi.fn(async () => {
+      throw new Error(`native ${label} getTools should not be called`)
+    }),
+    registerTool: vi.fn(),
+    executeTool: vi.fn()
+  }
+  Object.defineProperty(target, 'modelContext', {
+    value: native,
+    configurable: true,
+    writable: true,
+    enumerable: true
+  })
+  return native
+}
+
+afterEach(() => {
+  // 清掉实例属性，避免用例互相污染；原型上若仍有 getter 则交回 polyfill / jsdom 默认
+  try {
+    delete (document as Document & ModelContextHost).modelContext
+  } catch {
+    /* ignore */
+  }
+  try {
+    delete (navigator as Navigator & ModelContextHost).modelContext
+  } catch {
+    /* ignore */
+  }
+})
+
+describe('initializeBuiltinWebMCP forcePolyfill', () => {
+  it('复现：Chrome 原生 document.modelContext.getTools 会杀渲染进程 —— 前置 document 上已有非 polyfill 的伪 native；步骤 initializeBuiltinWebMCP()；期望替换为 JS polyfill 且不调用原生 getTools', async () => {
+    const native = installFakeNative(document, 'document')
+
+    initializeBuiltinWebMCP()
+
+    const ctx = (document as Document & ModelContextHost).modelContext as {
+      [key: string]: unknown
+      getTools?: () => Promise<unknown[]>
+    }
+    expect(ctx).toBeTruthy()
+    expect(ctx[POLYFILL_MARKER]).toBe(true)
+    expect(ctx).not.toBe(native)
+    expect(native.getTools).not.toHaveBeenCalled()
+
+    const tools = await ctx.getTools?.()
+    expect(Array.isArray(tools)).toBe(true)
+    expect(native.getTools).not.toHaveBeenCalled()
+  })
+
+  it('复现：只摘掉 document.modelContext 时 polyfill 会把 navigator 上的 native 接回 document —— 前置仅 navigator 有伪 native；步骤初始化；期望 document 上是 polyfill 而非该 native', () => {
+    try {
+      delete (document as Document & ModelContextHost).modelContext
+    } catch {
+      /* ignore */
+    }
+    const native = installFakeNative(navigator, 'navigator')
+
+    initializeBuiltinWebMCP()
+
+    const docCtx = (document as Document & ModelContextHost).modelContext as Record<string, unknown>
+    const navCtx = (navigator as Navigator & ModelContextHost).modelContext as Record<string, unknown>
+    expect(docCtx).toBeTruthy()
+    expect(docCtx[POLYFILL_MARKER]).toBe(true)
+    expect(docCtx).not.toBe(native)
+    expect(navCtx).not.toBe(native)
+    expect(native.getTools).not.toHaveBeenCalled()
+  })
+
+  it('复现：需要验证原生 API 时关闭强制 polyfill —— 前置 document 上伪 native；步骤 initializeBuiltinWebMCP({ forcePolyfill: false })；期望保留该 native', () => {
+    const native = installFakeNative(document, 'opt-out')
+
+    initializeBuiltinWebMCP({ forcePolyfill: false })
+
+    const ctx = (document as Document & ModelContextHost).modelContext
+    expect(ctx).toBe(native)
+    expect((ctx as Record<string, unknown>)[POLYFILL_MARKER]).toBeUndefined()
+  })
+
+  it('已是 polyfill 时再次初始化仍保留 marker，不拆掉 JS context', () => {
+    initializeBuiltinWebMCP()
+    const first = (document as Document & ModelContextHost).modelContext
+    expect((first as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
+
+    initializeBuiltinWebMCP()
+    const second = (document as Document & ModelContextHost).modelContext
+    expect(second).toBe(first)
+    expect((second as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
+  })
+
+  it('复现：Chromium 把 modelContext 放在 Document.prototype —— 前置原型 getter 返回伪 native；步骤默认初始化；期望实例上是 polyfill 且不调用原生 getTools', async () => {
+    const native = {
+      getTools: vi.fn(async () => {
+        throw new Error('native prototype getTools should not be called')
+      }),
+      registerTool: vi.fn(),
+      executeTool: vi.fn()
+    }
+    const previous = Object.getOwnPropertyDescriptor(Document.prototype, 'modelContext')
+    Object.defineProperty(Document.prototype, 'modelContext', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return native
+      }
+    })
+    try {
+      delete (document as Document & ModelContextHost).modelContext
+    } catch {
+      /* ignore */
+    }
+
+    try {
+      initializeBuiltinWebMCP()
+
+      const ctx = (document as Document & ModelContextHost).modelContext as Record<string, unknown>
+      expect(ctx).toBeTruthy()
+      expect(ctx[POLYFILL_MARKER]).toBe(true)
+      expect(ctx).not.toBe(native)
+      expect(native.getTools).not.toHaveBeenCalled()
+      const tools = await (ctx as { getTools: () => Promise<unknown[]> }).getTools()
+      expect(Array.isArray(tools)).toBe(true)
+    } finally {
+      if (previous) {
+        Object.defineProperty(Document.prototype, 'modelContext', previous)
+      } else {
+        delete (Document.prototype as ModelContextHost).modelContext
+      }
+    }
+  })
+})

--- a/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool-dispatch.test.ts
@@ -90,6 +90,7 @@ vi.mock('../../page-tools/handlers/clipboard', () => ({
 }))
 
 import { registerPageAgentTool } from '../../page-tools/page-agent-tool'
+import { initializeBuiltinWebMCP } from '../../page-tools/initialize-builtin-WebMCP'
 import type { PageAgentToolInput } from '../../page-tools/schema'
 import { setPageAgentToolConfig } from '../../page-tools/tool-config'
 
@@ -152,6 +153,8 @@ function resetWindowGlobals() {
 }
 
 function captureExecute(): PageAgentExecute {
+  // 5.x polyfill 无 import 副作用，须先初始化才能包一层 registerTool
+  initializeBuiltinWebMCP()
   const mcp = (document as DocumentWithModelContext).modelContext
   if (!mcp?.registerTool) {
     throw new Error('document.modelContext.registerTool unavailable')

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -34,12 +34,15 @@ function resetWindowGlobals() {
   delete window.__webmcpcli_toolConfig
   delete window.__webmcpcli_beforeGetBrowserState
   if ((window as any).__pageAgentToolAbortController) {
-    ;(window as any).__pageAgentToolAbortController.abort()
+    try {
+      ;(window as any).__pageAgentToolAbortController.abort()
+    } catch {
+      // 5.x registerTool 在 abort 后可能以 AbortError reject，由调用方 catch
+    }
     delete (window as any).__pageAgentToolAbortController
   }
-  // 注意：initializeBuiltinWebMCP() 内部用模块级单例 flag 控制只初始化一次 document.modelContext，
-  // 且没有对外暴露重置能力，因此这里不删除 document.modelContext，避免二次调用时因单例 flag
-  // 仍为 true 而不会重新创建 modelContext，导致 registerTool 拿到 undefined
+  // initializeBuiltinWebMCP 在已有 polyfill 时幂等；其它用例可能已装上 document.modelContext，
+  // 此处不删除，避免误伤并行/先后用例里的 registerTool
 }
 
 beforeEach(() => {
@@ -194,7 +197,7 @@ describe('registerPageAgentTool - 工具注册与注销机制', () => {
     const originalRegister = (document as any).modelContext.registerTool
     ;(document as any).modelContext.registerTool = (tool: any, options: any) => {
       if (tool.name === 'page-agent-tool') execute = tool.execute
-      originalRegister.call((document as any).modelContext, tool, options)
+      return originalRegister.call((document as any).modelContext, tool, options)
     }
 
     registerPageAgentTool()

--- a/packages/webmcp-cli/src/inject/page-init.ts
+++ b/packages/webmcp-cli/src/inject/page-init.ts
@@ -1,4 +1,3 @@
-import { initializeWebMCPPolyfill } from '@mcp-b/webmcp-polyfill'
 import {
   registerPageAgentTool,
   consoleCloudPageAgentToolOptions,
@@ -39,7 +38,7 @@ function initWebMcpCliPage(): void {
     return
   }
 
-  initializeWebMCPPolyfill()
+  // registerPageAgentTool 内部 initializeBuiltinWebMCP() 默认 forcePolyfill，避免直调 polyfill 沿用会崩溃的原生 modelContext
   registerPageAgentTool(resolvePageAgentToolOptions())
 
   window.__webmcpcli_tools = []

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -62,8 +62,8 @@ catalog:
 
   # 第3方ai 相关依赖
   '@page-agent/page-controller': ^1.10.0
-  '@mcp-b/webmcp-polyfill': ^3.0.0
-  '@mcp-b/webmcp-types': ^3.0.0
+  '@mcp-b/webmcp-polyfill': ^5.1.0
+  '@mcp-b/webmcp-types': ^5.1.0
   # 浏览器内 ARIA 树序列化 + Diff
   'dom-accessibility-api': ^0.6.3
   'aria-query': ^5.3.2


### PR DESCRIPTION
## Summary
- Chrome 152.0.7977.83 Origin Trial 下原生 `document.modelContext.getTools() 可能触发 `RESULT_CODE_KILLED_BAD_MESSAGE` 杀掉渲染进程。上游 `@mcp-b/webmcp-polyfill` 见 native 即跳过且已删除 `forceOverride`。
- `initializeBuiltinWebMCP()` 默认 `forcePolyfill: true`：先影子化 `document` / `navigator` 上的非 polyfill 实现，再安装 JS polyfill；5.x 把 getter 装在 `Document.prototype` 时，再把 polyfill 挂回 document 实例。`registerPageAgentTool()` / webmcp-cli 注入走同一路径。
- catalog 将 `@mcp-b/webmcp-polyfill`、`@mcp-b/webmcp-types` 升到 5.1.0；附 Spec `REQ-20260904-force-webmcp-polyfill` 与单测。确认原生可用时可传 `{ forcePolyfill: false }`。
- 同步将 `@opentiny/next-sdk` / `@opentiny/next-remoter` 版本升到 0.4.9。

## Test plan
- [ ] `pnpm -F @opentiny/next-sdk test`（含 `initialize-builtin-WebMCP` 强制 polyfill / 原型 getter / `forcePolyfill: false` 场景）
- [ ] 在已开启 WebMCP Origin Trial 的最新 Chrome 打开 doc-ai（或任意调用 `registerPageAgentTool` 的页面）：页面应能正常加载，`getTools()` 不崩 tab
- [ ] 确认 `document.modelContext.__isWebMCPPolyfill === true`，业务 `registerTool` 仍可用
- [ ] 需要验证原生 API 时：`initializeBuiltinWebMCP({ forcePolyfill: false })` 仍保留已有 native
- [ ] **请从本 PR 中移除 `packages/doc-ai/src/App.vue` 的明文 `llmConfig.apiKey`，不要合入密钥**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - WebMCP initialization now uses the JavaScript polyfill by default, helping avoid crashes in Chromium’s experimental native implementation.
  - Added an option to retain native WebMCP behavior when it is confirmed stable.
  - Page-agent tool setup now initializes WebMCP automatically.

- **Bug Fixes**
  - Registration failures are handled gracefully and reported as warnings instead of unhandled promise rejections.

- **Documentation**
  - Updated English and Chinese guides with initialization behavior, configuration guidance, and compatibility notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->