### PR TITLE
fix: 完成contenteditable元素的a11y的获取

### DIFF
--- a/docs/webmcp-sdk/page-agent-tool.md
+++ b/docs/webmcp-sdk/page-agent-tool.md
@@ -59,7 +59,7 @@ getPageAgentToolConfig() // { enableHighlight: false, a11yConfig: { roles: [...]
 | `browserState`      | 获取页面无障碍树（YAML）    | `responseMode`: `full` / `diff` / `both` |
 | `searchTree`        | 按关键词搜索无障碍树        | `query`、`contextLines`、`maxMatches`    |
 | `click`             | 点击元素                    | `index`                                  |
-| `fill`              | 填写输入框                  | `index`、`text`                          |
+| `fill`              | 填写 input / textarea / contenteditable 编辑宿主 | `index`、`text`                          |
 | `select`            | 选择下拉选项                | `index`、`text`                          |
 | `scroll`            | 滚动页面或容器              | `down` / `right`、`numPages` / `pixels`  |
 | `hover`             | 悬浮元素（触发 tooltip 等） | `index`                                  |
@@ -67,6 +67,8 @@ getPageAgentToolConfig() // { enableHighlight: false, a11yConfig: { roles: [...]
 | `clipboard`         | 读写系统剪切板              | `text`（见下文）                         |
 
 执行 `click`、`fill`、`select`、`hover` 前通常需先调用 `browserState` 获取最新 ref 索引；`clipboard` 不依赖 `index`，也不展示 SimulatorMask。
+
+`browserState` 产出的无障碍树会把**编辑宿主**（元素自身声明 `contenteditable="true"` / `""` / `"plaintext-only"`，不含仅从祖先继承的子孙）识别为可填写控件：隐式角色 `textbox`（显式 `role` 与 `a11yConfig.roles` 优先），分配 `#N` ref，并带 `[contenteditable]` token（`plaintext-only` 时为 `[contenteditable=plaintext-only]`）。有可见文本时还会输出 `value="…"`，便于 `fill` 前后做 Diff。`contenteditable="false"` 与 `aria-disabled` 的编辑区不分配 ref。`fill` 使用该 `#N` 即可写入富文本框，无需再为每个站点单独配 whitelist。
 
 ---
 

--- a/packages/next-sdk/page-tools/a11y/config.ts
+++ b/packages/next-sdk/page-tools/a11y/config.ts
@@ -289,6 +289,22 @@ export function defineA11yConfig(config: A11yConfig): A11yConfig {
 
 // ─── 角色 / 状态解析 ─────────────────────────────────────────────────────
 
+/**
+ * 判断元素是否为编辑宿主（自身声明 contenteditable，而非从祖先继承）。
+ * HTML-AAM：无显式 role 时隐式角色为 textbox。
+ * `contenteditable="false"` / `inherit` 不算。
+ */
+export function isEditingHost(el: Element): boolean {
+  if (!(el instanceof HTMLElement)) return false
+  const ce = el.contentEditable
+  if (ce === 'true' || ce === 'plaintext-only') return true
+  // jsdom 等环境对 IDL contentEditable 实现可能不完整，回退读属性
+  const raw = el.getAttribute('contenteditable')
+  if (raw === null) return false
+  const v = raw.trim().toLowerCase()
+  return v === '' || v === 'true' || v === 'plaintext-only'
+}
+
 /** 命中的声明式 role 规则（未命中配置规则时返回 null，再走显式 role / 标签隐式映射） */
 function findMatchedRoleRule(el: Element, resolved: ResolvedA11yConfig): A11yRoleRule | null {
   const explicit = el.getAttribute('role')
@@ -316,6 +332,8 @@ function computeRole(
     const inputType = (el as HTMLInputElement).type?.toLowerCase() ?? 'text'
     return INPUT_TYPE_ROLE[inputType] ?? 'textbox'
   }
+  // HTML-AAM：编辑宿主隐式 textbox（显式 role / roles 规则 / input[type] 优先）
+  if (isEditingHost(el)) return 'textbox'
   return TAG_ROLE_MAP[tag] ?? 'generic'
 }
 
@@ -445,6 +463,14 @@ function computeStates(el: Element, resolved: ResolvedA11yConfig): string[] {
     if (val !== undefined && val !== '') {
       tokens.push(`value="${val}"`)
     }
+  }
+  // 编辑宿主：标记可填，并用可见文本作为 value（供 fill 后 Diff）
+  if (isEditingHost(el)) {
+    const ce = (el as HTMLElement).contentEditable
+    const rawCe = (el.getAttribute('contenteditable') ?? '').trim().toLowerCase()
+    tokens.push(ce === 'plaintext-only' || rawCe === 'plaintext-only' ? 'contenteditable=plaintext-only' : 'contenteditable')
+    const text = ((el as HTMLElement).innerText || el.textContent || '').replace(/\s+/g, ' ').trim()
+    if (text) tokens.push(`value="${text}"`)
   }
   const valuenow = aria('aria-valuenow')
   if (valuenow) tokens.push(`valuenow="${valuenow}"`)

--- a/packages/next-sdk/page-tools/a11y/config.ts
+++ b/packages/next-sdk/page-tools/a11y/config.ts
@@ -469,7 +469,7 @@ function computeStates(el: Element, resolved: ResolvedA11yConfig): string[] {
     const ce = (el as HTMLElement).contentEditable
     const rawCe = (el.getAttribute('contenteditable') ?? '').trim().toLowerCase()
     tokens.push(ce === 'plaintext-only' || rawCe === 'plaintext-only' ? 'contenteditable=plaintext-only' : 'contenteditable')
-    const text = ((el as HTMLElement).innerText || el.textContent || '').replace(/\s+/g, ' ').trim()
+    const text = ((el as HTMLElement).innerText ?? el.textContent ?? '').replace(/\s+/g, ' ').trim()
     if (text) tokens.push(`value="${text}"`)
   }
   const valuenow = aria('aria-valuenow')

--- a/packages/next-sdk/page-tools/a11y/utils.ts
+++ b/packages/next-sdk/page-tools/a11y/utils.ts
@@ -6,7 +6,7 @@
  */
 
 import { isTabbable } from 'tabbable'
-import { resolveA11yRole, type ResolvedA11yConfig } from './config'
+import { isEditingHost, resolveA11yRole, type ResolvedA11yConfig } from './config'
 import { deepQuerySelectorAll } from '../utils/dom'
 
 /**
@@ -195,7 +195,7 @@ export function collectDescendantText(el: Element, config?: ResolvedA11yConfig):
         const isOwnPointer = hasOwnPointerCursor(element)
         const isMeaningfullyInteractive = isTrulyInteractive && !(role === 'generic' && !isOwnPointer)
 
-        if (isMeaningfullyInteractive || isInteractiveTag || isInteractiveRole) {
+        if (isMeaningfullyInteractive || isInteractiveTag || isInteractiveRole || isEditingHost(element)) {
           return
         }
       }

--- a/packages/next-sdk/page-tools/a11y/vnode.ts
+++ b/packages/next-sdk/page-tools/a11y/vnode.ts
@@ -8,7 +8,7 @@ import { computeAccessibleName } from 'dom-accessibility-api'
 import { isTabbable } from 'tabbable'
 import type { VNode, RefMap, A11yTreeShapeOptions } from './types'
 import type { ResolvedA11yConfig } from './config'
-import { resolveA11yInfo } from './config'
+import { isEditingHost, resolveA11yInfo } from './config'
 import {
   isHidden,
   isNonContentElement,
@@ -102,7 +102,7 @@ export function buildVNode(
     const isDropdown = tag === 'select' || role === 'combobox' || role === 'listbox'
     if (!isDropdown) {
       const isInteractiveTag = ['button', 'a', 'input', 'textarea', 'li', 'label'].includes(tag)
-      if (isTrulyInteractive || isWhitelisted || isVisuallyClickable || hasClickableCursor || isInteractiveTag || role === 'listitem' || role === 'option' || role === 'button') {
+      if (isTrulyInteractive || isWhitelisted || isVisuallyClickable || hasClickableCursor || isInteractiveTag || isEditingHost(el) || role === 'listitem' || role === 'option' || role === 'button') {
         name = collectDescendantText(el, config)
       }
     }
@@ -189,7 +189,9 @@ export function buildVNode(
     // 虽是真正的可点击边界，仍会因 generic+空名被漏判。
     (!isDisabled && hasClickableCursor) ||
     // 有 tooltip 的元素分配 ref，使 AI 能 hover 触发动态 tip
-    hasTooltip
+    hasTooltip ||
+    // 编辑宿主可 fill，即使显式 role 不是 textbox（如 combobox）也要暴露 ref
+    (!isDisabled && isEditingHost(el))
 
   let ref: number | undefined
   if (interactive) {

--- a/packages/next-sdk/page-tools/a11y/vnode.ts
+++ b/packages/next-sdk/page-tools/a11y/vnode.ts
@@ -188,8 +188,9 @@ export function buildVNode(
     // 无需再要求 role≠generic 或 name≠''——否则无文本的图标按钮（tp-icon.common-icon 等）
     // 虽是真正的可点击边界，仍会因 generic+空名被漏判。
     (!isDisabled && hasClickableCursor) ||
-    // 有 tooltip 的元素分配 ref，使 AI 能 hover 触发动态 tip
-    hasTooltip ||
+    // 有 tooltip 的元素分配 ref，使 AI 能 hover 触发动态 tip。
+    // 禁用编辑宿主不得借 title/tooltip 拿到 ref，否则 fill 可定位 aria-disabled 编辑区。
+    (hasTooltip && !(isDisabled && isEditingHost(el))) ||
     // 编辑宿主可 fill，即使显式 role 不是 textbox（如 combobox）也要暴露 ref
     (!isDisabled && isEditingHost(el))
 

--- a/packages/next-sdk/page-tools/schema.ts
+++ b/packages/next-sdk/page-tools/schema.ts
@@ -15,7 +15,7 @@ export const inputSchema = z.object({
     .describe(`执行的动作名称, 每一次执行 'click', 'fill', 'select', 'hover'动作之前，**必须**要先调用 'browserState' 去获取页面的最新状态。 
       browserState: '查询整个页面的浏览器状态;返回页面的标题、URL、YAML格式的语义化页面树',
       click: '根据元素索引点击;',
-      fill: '根据元素索引填写文本;'; 
+      fill: '根据元素索引填写文本（目标为 input、textarea 或 contenteditable 编辑宿主，索引来自 browserState YAML 中的 #N）;'; 
       select: '根据元素索引选择下拉框选项;'; 
       scroll: '滚动页面的动作，可以指定水平滚动还是上下滚动; 不带元素索引时：滚动整个文档。带元素索引时：滚动该索引处的容器（或其最近的可滚动祖先元素）'
       executeJavascript: '执行javascript代码'

--- a/packages/next-sdk/skills/page-agent/SKILL.md
+++ b/packages/next-sdk/skills/page-agent/SKILL.md
@@ -16,7 +16,7 @@ description: >-
 - 无障碍树构建、剪枝、Static-Lift、序列化语义
 - 需要更新 `docs/webmcp-sdk/page-agent-tool.md` 的行为说明
 
-近期示例：[`specs/REQ-20260722-console-layout-landmark/`](../../specs/REQ-20260722-console-layout-landmark/)、[`specs/REQ-20260817-clipboard-handler/`](../../specs/REQ-20260817-clipboard-handler/)、[`specs/REQ-20260903-mask-cursor-lifecycle/`](../../specs/REQ-20260903-mask-cursor-lifecycle/)。
+近期示例：[`specs/REQ-20260904-contenteditable-a11y-ref/`](../../specs/REQ-20260904-contenteditable-a11y-ref/)、[`specs/REQ-20260903-mask-cursor-lifecycle/`](../../specs/REQ-20260903-mask-cursor-lifecycle/)、[`specs/REQ-20260817-clipboard-handler/`](../../specs/REQ-20260817-clipboard-handler/)。
 
 拿不准是否琐碎 → **先问用户**，不要默认开写。
 
@@ -61,6 +61,7 @@ import {
 - `A11yRoleRule.name`：可选声明可访问名（不改 DOM），用于 landmark / 布局容器在 YAML 中保留分区名。
 - 站点预设：云控制台用 `consoleCloudPageAgentToolOptions` + `isConsoleCloudHost()`（含 `ti-app-layout-*` landmark）。
 - **`clipboard` action**：`text` 有值写剪切板、无值读剪切板；不依赖 `index`、不展示 mask；handler 见 `page-tools/handlers/clipboard.ts`。
+- **contenteditable**：`browserState` 将自身声明 `contenteditable` 的编辑宿主标为 `textbox`（显式 role 优先）、分配 ref、输出 `[contenteditable]` token；`fill` 用该 ref 填写。继承可编辑的子孙不单独占 ref。见 [`REQ-20260904-contenteditable-a11y-ref`](../../specs/REQ-20260904-contenteditable-a11y-ref/)。
 
 ## 测试落点
 

--- a/packages/next-sdk/specs/README.md
+++ b/packages/next-sdk/specs/README.md
@@ -20,6 +20,7 @@
 
 | Spec | 说明 |
 |---|---|
+| [`REQ-20260904-contenteditable-a11y-ref`](./REQ-20260904-contenteditable-a11y-ref/) | `browserState` 将 contenteditable 编辑宿主标为可填：textbox + ref + token |
 | [`REQ-20260903-mask-cursor-lifecycle`](./REQ-20260903-mask-cursor-lifecycle/) | 遮罩接管态默认不出光标；句柄透传 `showCursor`；操作结束收光标；`cursorMode` |
 | [`REQ-20260817-clipboard-handler`](./REQ-20260817-clipboard-handler/) | Page Agent `clipboard` action：读写系统剪切板（`text` 有值写、无值读） |
 | [`REQ-20260807-dev-entry`](./REQ-20260807-dev-entry/) | 新增 `dev` 入口：将 `dom-inspect` 等本地开发能力从主入口拆出 |

--- a/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/design.md
+++ b/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/design.md
@@ -1,0 +1,88 @@
+# Design：无障碍树识别 contenteditable 编辑宿主
+
+## 方案概述
+
+在角色解析与 ref 分配两处补齐「编辑宿主」语义，使 `browserState` 产出的 YAML / `refMap` 与已有 `fill` 能力对齐。
+
+判定只认**自身声明**的 `contenteditable`，避免继承可编辑子孙被当成独立填写目标。
+
+## 涉及模块 / 文件
+
+| 路径 | 职责 |
+| --- | --- |
+| `packages/next-sdk/page-tools/a11y/config.ts` | `isEditingHost`；`computeRole` 隐式 `textbox`；`computeStates` 输出 token / value |
+| `packages/next-sdk/page-tools/a11y/vnode.ts` | 未禁用的编辑宿主强制分配 ref；空名时收集子树文本 |
+| `packages/next-sdk/page-tools/a11y/utils.ts` | `collectDescendantText` 遇编辑宿主停止吸收，避免父节点兜底名吞掉编辑区 |
+| `packages/next-sdk/page-tools/schema.ts` | `fill` 描述写明覆盖 contenteditable |
+| `docs/webmcp-sdk/page-agent-tool.md` | 用户文档 |
+| `packages/next-sdk/skills/page-agent/SKILL.md` | 编码 Agent Skill |
+
+## 核心数据结构 / 类型定义
+
+无新公开类型。内部辅助：
+
+```typescript
+/** 自身声明 contenteditable 的编辑宿主（不含 inherit / false） */
+export function isEditingHost(el: Element): boolean {
+  if (!(el instanceof HTMLElement)) return false
+  const ce = el.contentEditable
+  if (ce === 'true' || ce === 'plaintext-only') return true
+  const raw = el.getAttribute('contenteditable')
+  if (raw === null) return false
+  const v = raw.trim().toLowerCase()
+  return v === '' || v === 'true' || v === 'plaintext-only'
+}
+```
+
+属性兜底是为了兼容 jsdom 等环境对 IDL `contentEditable` 实现不完整的情况。
+
+## 依赖变更
+
+无。
+
+## API / 行为变更
+
+| 符号或行为 | 变更类型 | 说明 |
+| --- | --- | --- |
+| `resolveA11yRole`（编辑宿主） | 修改 | 无显式 role / 未命中 roles 规则 / 非 `input[type]` 时隐式为 `textbox` |
+| `resolveA11yStates`（编辑宿主） | 修改 | 增加 `contenteditable` 或 `contenteditable=plaintext-only`；有文本时增加 `value="…"` |
+| `buildA11yTree` / `refMap` | 修改 | 未禁用的编辑宿主分配 ref |
+| `inputSchema` `fill` 描述 | 修改 | 写明目标含 contenteditable 编辑宿主 |
+| 公开包入口 | 无 | 不导出 `isEditingHost` |
+
+角色优先级保持：
+
+1. 命中的 `roles` 规则
+2. 显式 `role` 属性（排除 `presentation` / `none`）
+3. `input` 的 `type` 映射
+4. **编辑宿主 → `textbox`**（新增）
+5. `TAG_ROLE_MAP` / `generic`
+
+这样 `<p contenteditable>` / `<h1 contenteditable>` / `<div contenteditable>` 对 Agent 呈现为可填 `textbox`；`<input type="checkbox">` 不被 contenteditable 属性带偏；显式 `role="combobox"` 仍保留。
+
+## 数据流
+
+```mermaid
+flowchart TD
+  A[buildA11yTree] --> B[resolveA11yInfo]
+  B --> C{isEditingHost?}
+  C -->|是且无显式 role| D[role = textbox]
+  C -->|否| E[原有角色推断]
+  B --> F[tokens: contenteditable / value]
+  A --> G[buildVNode 分配 ref]
+  G --> H{未禁用且 isEditingHost 或 INTERACTIVE_ROLES.text}
+  H -->|是| I[写入 refMap，YAML 输出 #N]
+  I --> J[Agent fill index=N]
+```
+
+## 风险与兼容
+
+- **YAML 变长**：页面上每个富文本框多一行带 ref 的 `textbox`。这是预期，否则 fill 无法寻址。
+- **继承子孙**：只给宿主 ref，避免编辑区内每个 `<p>` 都变成可操作节点导致高亮泛滥。
+- **`generic` + `tabindex` 过滤**：编辑宿主改为 `textbox` 后可走 `INTERACTIVE_ROLES`；同时在 `interactive` 条件中显式加入 `isEditingHost`，覆盖「显式 role 不是 textbox」的情况。
+- **向后兼容**：仅新增识别，不改变 input/textarea/button 既有行为。
+
+## 备选方案（未采用）
+
+- **仅靠 whitelist / 站点规则**：无法覆盖任意 contenteditable，与 `fill` 已支持任意编辑宿主不一致。
+- **凡 `isContentEditable` 都分配 ref**：会把宿主内部每个子孙都标成可填，不可用。

--- a/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/requirements.md
+++ b/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/requirements.md
@@ -1,0 +1,80 @@
+# Spec：无障碍树识别 contenteditable 编辑宿主
+
+## 元信息
+
+- 状态：已交付
+- 主责包：`packages/next-sdk`
+- 关联 Issue：无（用户口头需求）
+
+## 背景
+
+`page-agent-tool` 的 `fill` 已能对 `input`、`textarea` 以及任意 `contenteditable` 元素写入文本（`handleFill` → `inputTextElement`）。但 `browserState` 构建无障碍树时：
+
+1. `div[contenteditable]` 等非表单标签隐式角色是 `generic`；
+2. `isMeaningfullyInteractive` 会把「generic 且无 pointer 手势」的可聚焦节点当成结构焦点容器滤掉；
+3. `isSemanticInteractiveTag` 只覆盖 `a/button/input/select/textarea`。
+
+因此富文本编辑区（常见于知乎、CSDN、各类 CMS）在 YAML 中没有 ref，Agent 无法把 `fill` 对上目标。
+
+## 领域术语表
+
+- **编辑宿主（editing host）**：元素**自身**声明了 `contenteditable="true"` / `""` / `"plaintext-only"`，而非仅从祖先继承。对应 IDL `contentEditable === 'true' | 'plaintext-only'`。
+- **继承可编辑子孙**：父级是编辑宿主时，子节点 `contentEditable === 'inherit'` 且 `isContentEditable === true`。它们不是独立填写目标，不得各分一个 ref。
+
+## 目标用户 / 场景
+
+- Agent 调用 `browserState` 后，在 YAML 中看到富文本编辑区为 `textbox #N [contenteditable]`，再用 `fill` 填写。
+- 集成方无需为每个站点的编辑器单独写 `whitelist` / `roles`。
+
+## 参考资料 / 上下文
+
+- HTML-AAM：编辑宿主隐式 ARIA 角色为 `textbox`
+- `packages/next-sdk/page-tools/handlers/fill.ts`：已支持 contenteditable
+- `packages/next-sdk/page-tools/a11y/vnode.ts`：ref 分配
+- `packages/next-sdk/page-tools/a11y/config.ts`：`computeRole` / `computeStates`
+
+## 范围
+
+### In Scope
+
+- 识别编辑宿主：隐式角色 `textbox`（显式 `role` / `roles` 规则 / `input[type]` 优先）。
+- 为未禁用的编辑宿主分配 ref，写入 `refMap`，YAML 输出 `#N`。
+- 输出 `contenteditable` token（`plaintext-only` 时为 `contenteditable=plaintext-only`）。
+- 有可见文本时输出 `value="…"` token（与 input/textarea 一致，供 fill 后 Diff）。
+- 继承可编辑子孙、`contenteditable="false"` 不因可编辑性获得 ref。
+- 用户文档 / Skill / `fill` schema 描述同步。
+
+### Out of Scope
+
+- 修改 `handleFill` 的写入实现（已支持 contenteditable）。
+- 为编辑宿主截断超长 `value`（与 input/textarea 现状对齐，不新增截断）。
+- 暴露新的公开配置项或 `PageAgentToolOptions` 字段。
+- 识别无 `contenteditable` 属性、仅靠 iframe/CodeMirror 等内容的第三方编辑器。
+
+## 用户故事与验收标准
+
+1. 作为 Agent，我希望 `div[contenteditable=true]` 出现在无障碍树中并带 ref，以便对它调用 `fill`。
+   - 验收：`buildA11yTree` 的 `refMap` 包含该元素；YAML 含 `textbox #<n>` 与 `[contenteditable]`。
+2. 作为 Agent，我希望空的编辑宿主也有 ref，以便向空白富文本框填写。
+   - 验收：空 `div[contenteditable]` 仍进入 `refMap`。
+3. 作为 Agent，我希望只给编辑宿主本身分配 ref，而不是每个内部 `<p>`/`<span>` 各一个。
+   - 验收：宿主在 `refMap` 中；仅继承可编辑的子孙不在 `refMap` 中。
+4. 作为 Agent，我希望 `contenteditable="false"` 不被当成可填字段。
+   - 验收：该元素不因可编辑性获得 ref（除非另有 button 等交互语义）。
+5. 作为 Agent，我希望 `plaintext-only` 同样可填，并能从 token 区分模式。
+   - 验收：角色 `textbox`、有 ref、token 含 `contenteditable=plaintext-only`。
+6. 作为集成方，我希望显式 `role` 不被 contenteditable 覆盖。
+   - 验收：`<div role="combobox" contenteditable="true">` 角色仍为 `combobox`，但仍有 ref 与 `contenteditable` token。
+
+## 非功能要求
+
+- 不新增公开 API 符号（`isEditingHost` 仅模块内导出，不进包入口）。
+- 不改变 input/textarea 既有角色与 ref 行为。
+- `aria-disabled="true"` 的编辑宿主不分配 ref（与其它交互角色一致）。
+
+## 完成定义
+
+- [x] `design.md` / `tasks.md` 已齐
+- [x] 对应自动化测试已在 `tasks.md` 列出并实现
+- [x] `docs/webmcp-sdk/page-agent-tool.md` 与 `skills/page-agent/SKILL.md` 已更新
+- [x] `pnpm -F @opentiny/next-sdk test` 通过

--- a/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/tasks.md
+++ b/packages/next-sdk/specs/REQ-20260904-contenteditable-a11y-ref/tasks.md
@@ -1,0 +1,22 @@
+# Tasks：无障碍树识别 contenteditable 编辑宿主
+
+## 任务列表
+
+- [x] Task 1: 角色 / 状态解析识别编辑宿主
+  - 产物：`packages/next-sdk/page-tools/a11y/config.ts`（`isEditingHost`、`computeRole`、`computeStates`）
+  - [x] 测试：`packages/next-sdk/test/page-tools/a11y/config.test.ts`
+- [x] Task 2: 构建树时为编辑宿主分配 ref，且不传染给继承子孙
+  - 产物：`packages/next-sdk/page-tools/a11y/vnode.ts`、`packages/next-sdk/page-tools/a11y/utils.ts`
+  - [x] 测试：`packages/next-sdk/test/page-tools/a11y/build.test.ts`
+- [x] Task 3: schema / 用户文档 / Skill
+  - 产物：`packages/next-sdk/page-tools/schema.ts`、`docs/webmcp-sdk/page-agent-tool.md`、`packages/next-sdk/skills/page-agent/SKILL.md`、`packages/next-sdk/specs/README.md`
+
+## 依赖顺序
+
+1 → 2 → 3
+
+## 验收命令
+
+```bash
+pnpm -F @opentiny/next-sdk test
+```

--- a/packages/next-sdk/test/page-tools/a11y/build.test.ts
+++ b/packages/next-sdk/test/page-tools/a11y/build.test.ts
@@ -688,6 +688,77 @@ describe('buildA11yTree - 通用 cursor:pointer 可点击元素识别', () => {
   })
 })
 
+describe('buildA11yTree - contenteditable 编辑宿主分配 ref', () => {
+  it('复现：div[contenteditable] 在 browserState 中无 ref，fill 无法寻址 —— 前置无 role 的富文本框；步骤 buildA11yTree；期望 textbox + ref + contenteditable token', () => {
+    const root = setupRoot(`<div id="editor" contenteditable="true">正文草稿</div>`)
+    const editor = root.querySelector('#editor') as HTMLElement
+    const { yaml, refMap } = buildA11yTree(root)
+
+    expect(Array.from(refMap.values())).toContain(editor)
+    expect(yaml).toMatch(/textbox #\d+/)
+    expect(yaml).toMatch(/contenteditable/)
+    expect(yaml).toMatch(/value=\\"正文草稿\\"/)
+  })
+
+  it('空编辑宿主仍分配 ref，便于向空白富文本框 fill', () => {
+    const root = setupRoot(`<div id="empty-editor" contenteditable="true"></div>`)
+    const editor = root.querySelector('#empty-editor') as HTMLElement
+    const { yaml, refMap } = buildA11yTree(root)
+
+    expect(Array.from(refMap.values())).toContain(editor)
+    expect(yaml).toMatch(/textbox #\d+/)
+  })
+
+  it('只给编辑宿主分配 ref，继承可编辑的内部 p/span 不各自占 ref', () => {
+    const root = setupRoot(`
+      <div id="host" contenteditable="true">
+        <p id="para">段落</p>
+        <span id="inner">片段</span>
+      </div>
+    `)
+    const host = root.querySelector('#host') as HTMLElement
+    const para = root.querySelector('#para') as HTMLElement
+    const inner = root.querySelector('#inner') as HTMLElement
+    const { refMap } = buildA11yTree(root)
+    const values = Array.from(refMap.values())
+
+    expect(values).toContain(host)
+    expect(values).not.toContain(para)
+    expect(values).not.toContain(inner)
+  })
+
+  it('contenteditable=false 不因可编辑性获得 ref', () => {
+    const root = setupRoot(`<div id="locked" contenteditable="false">只读块</div>`)
+    const locked = root.querySelector('#locked') as HTMLElement
+    const { refMap } = buildA11yTree(root)
+    expect(Array.from(refMap.values())).not.toContain(locked)
+  })
+
+  it('plaintext-only 编辑宿主同样分配 ref', () => {
+    const root = setupRoot(`<div id="plain" contenteditable="plaintext-only">纯文本</div>`)
+    const plain = root.querySelector('#plain') as HTMLElement
+    const { yaml, refMap } = buildA11yTree(root)
+    expect(Array.from(refMap.values())).toContain(plain)
+    expect(yaml).toMatch(/contenteditable=plaintext-only/)
+  })
+
+  it('显式 role 保留，但仍分配 ref 并标记 contenteditable', () => {
+    const root = setupRoot(`<div id="combo" role="combobox" contenteditable="true">可搜</div>`)
+    const combo = root.querySelector('#combo') as HTMLElement
+    const { yaml, refMap } = buildA11yTree(root)
+    expect(Array.from(refMap.values())).toContain(combo)
+    expect(yaml).toMatch(/combobox #\d+/)
+    expect(yaml).toMatch(/contenteditable/)
+  })
+
+  it('aria-disabled 的编辑宿主不分配 ref', () => {
+    const root = setupRoot(`<div id="off" contenteditable="true" aria-disabled="true">禁用编辑</div>`)
+    const off = root.querySelector('#off') as HTMLElement
+    const { refMap } = buildA11yTree(root)
+    expect(Array.from(refMap.values())).not.toContain(off)
+  })
+})
+
 /** 统计某 accessible name 是否在多行 YAML 中重复出现（父子同名的典型信号） */
 function yamlHasDuplicateAccessibleName(lines: string[], name: string): boolean {
   const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/packages/next-sdk/test/page-tools/a11y/build.test.ts
+++ b/packages/next-sdk/test/page-tools/a11y/build.test.ts
@@ -757,6 +757,15 @@ describe('buildA11yTree - contenteditable 编辑宿主分配 ref', () => {
     const { refMap } = buildA11yTree(root)
     expect(Array.from(refMap.values())).not.toContain(off)
   })
+
+  it('复现：aria-disabled 编辑宿主带 title 时仍被 tooltip 分支分配 ref —— 前置 contenteditable + aria-disabled + title；步骤 buildA11yTree；期望不进 refMap', () => {
+    const root = setupRoot(
+      `<div id="locked-tip" contenteditable="true" aria-disabled="true" title="已锁定">禁用编辑</div>`,
+    )
+    const locked = root.querySelector('#locked-tip') as HTMLElement
+    const { refMap } = buildA11yTree(root)
+    expect(Array.from(refMap.values())).not.toContain(locked)
+  })
 })
 
 /** 统计某 accessible name 是否在多行 YAML 中重复出现（父子同名的典型信号） */

--- a/packages/next-sdk/test/page-tools/a11y/config.test.ts
+++ b/packages/next-sdk/test/page-tools/a11y/config.test.ts
@@ -228,6 +228,39 @@ describe('resolveA11yStates - 标准 ARIA 零配置检测', () => {
     expect(resolveA11yStates(el('<a target="_self"></a>'))).toContain('target=_self')
     expect(resolveA11yStates(el('<a></a>'))).not.toContain('target=_blank')
   })
+
+  it('contenteditable 编辑宿主输出 contenteditable token 与 value', () => {
+    const editor = el('<div contenteditable="true">已有正文</div>')
+    const tokens = resolveA11yStates(editor)
+    expect(tokens).toContain('contenteditable')
+    expect(tokens).toContain('value="已有正文"')
+  })
+
+  it('contenteditable=plaintext-only 输出专用 token', () => {
+    expect(resolveA11yStates(el('<div contenteditable="plaintext-only">纯文本</div>'))).toContain(
+      'contenteditable=plaintext-only',
+    )
+  })
+})
+
+describe('resolveA11yRole - contenteditable 编辑宿主', () => {
+  it('无显式 role 的编辑宿主隐式为 textbox', () => {
+    expect(resolveA11yRole(el('<div contenteditable="true"></div>'))).toBe('textbox')
+    expect(resolveA11yRole(el('<div contenteditable></div>'))).toBe('textbox')
+    expect(resolveA11yRole(el('<p contenteditable="true">段</p>'))).toBe('textbox')
+  })
+
+  it('contenteditable=false 不视为编辑宿主', () => {
+    expect(resolveA11yRole(el('<div contenteditable="false">x</div>'))).toBe('generic')
+  })
+
+  it('显式 role 优先于 contenteditable 隐式 textbox', () => {
+    expect(resolveA11yRole(el('<div role="combobox" contenteditable="true"></div>'))).toBe('combobox')
+  })
+
+  it('input[type] 优先于 contenteditable', () => {
+    expect(resolveA11yRole(el('<input type="checkbox" contenteditable="true" />'))).toBe('checkbox')
+  })
 })
 
 describe('resolveA11yStates - 自定义规则', () => {

--- a/packages/next-sdk/test/page-tools/a11y/config.test.ts
+++ b/packages/next-sdk/test/page-tools/a11y/config.test.ts
@@ -241,6 +241,15 @@ describe('resolveA11yStates - 标准 ARIA 零配置检测', () => {
       'contenteditable=plaintext-only',
     )
   })
+
+  it('复现：编辑宿主 innerText 为空时不得回退 textContent 暴露隐藏文案 —— 前置仅 display:none 子孙；步骤 resolveA11yStates；期望无 value token', () => {
+    const editor = el('<div contenteditable="true"><span style="display:none">secret</span></div>') as HTMLElement
+    // jsdom 的 innerText 为 undefined，这里模拟浏览器：可见文本为空字符串
+    Object.defineProperty(editor, 'innerText', { configurable: true, get: () => '' })
+    const tokens = resolveA11yStates(editor)
+    expect(tokens).toContain('contenteditable')
+    expect(tokens.some((t) => t.startsWith('value='))).toBe(false)
+  })
 })
 
 describe('resolveA11yRole - contenteditable 编辑宿主', () => {


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

新增 contenteditable元素的抓取。 原来的时候 ，如果没有内容，就会忽略掉这个节点。
-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Contenteditable editing hosts are now recognized as fillable textbox controls.
  * Editable hosts receive accessibility references, contenteditable and value details, and support targeting through `fill`.
  * Explicit roles and existing input behavior remain supported.

* **Bug Fixes**
  * Inherited editable descendants, disabled hosts, and `contenteditable="false"` elements are excluded from fillable references.

* **Documentation**
  * Updated fill guidance, accessibility documentation, specifications, and Page Agent instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->