### PR TITLE
fix(next-sdk): 阻止初始化时触发 navigator.modelContext 废弃告警与误判

### DIFF
--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
+++ b/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
@@ -116,12 +116,40 @@ function revealPolyfillOnDocument(): void {
   }
 }
 
+/**
+ * 摘除 navigator（及 Navigator.prototype）上的 modelContext getter。
+ *
+ * WebMCP 2026-05-27 草案将 modelContext 从 Navigator 迁移到了 Document。
+ * @mcp-b/webmcp-polyfill@5.1.0 为兼容旧版在 navigator 上挂载了带 warn 的 getter；
+ * 但其 initializeWebMCPPolyfill() 内部直接访问了 `nav.modelContext` 探测旧规范原生实现。
+ * 若环境中已挂有该 getter，此属性访问会触发自身警告且误走分支。
+ * 在安装前先清除该 getter，由 polyfill 在初始化末尾重新建立旧版兼容 alias。
+ */
+function neutralizeDeprecatedNavigatorModelContext(): void {
+  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
+  if (!nav) return
+
+  const targets = [nav, Object.getPrototypeOf(nav)].filter(Boolean)
+  for (const target of targets) {
+    const desc = Object.getOwnPropertyDescriptor(target, 'modelContext')
+    if (desc?.get && desc.configurable) {
+      Reflect.deleteProperty(target, 'modelContext')
+    }
+  }
+}
+
 export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions) => {
   if (!isBrowser()) return
+
+  // 若 document 上已存在合格的 JS polyfill，直接幂等返回，无需重复执行安装
+  const currentCtx = readModelContext(document as Document & ModelContextHost)
+  if (isWebMCPPolyfill(currentCtx)) return
 
   const forcePolyfill = options?.forcePolyfill !== false
 
   try {
+    neutralizeDeprecatedNavigatorModelContext()
+
     if (!forcePolyfill) {
       initializeWebMCPPolyfill()
       return
@@ -141,3 +169,4 @@ export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions
     console.warn('[next-sdk] 自动注入 modelContext polyfill 失败:', err)
   }
 }
+

--- a/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
+++ b/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
@@ -68,15 +68,25 @@ describe('initializeBuiltinWebMCP forcePolyfill', () => {
     expect((ctx as Record<string, unknown>)[POLYFILL_MARKER]).toBeUndefined()
   })
 
-  it('已是 polyfill 时再次初始化仍保留 marker，不拆掉 JS context', () => {
-    initializeBuiltinWebMCP()
-    const first = (document as Document & ModelContextHost).modelContext
-    expect((first as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
+  it('已是 polyfill 时再次初始化仍保留 marker，不拆掉 JS context 且不触发告警', () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+    try {
+      initializeBuiltinWebMCP()
+      const first = (document as Document & ModelContextHost).modelContext
+      expect((first as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
 
-    initializeBuiltinWebMCP()
-    const second = (document as Document & ModelContextHost).modelContext
-    expect(second).toBe(first)
-    expect((second as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
+      initializeBuiltinWebMCP()
+      const second = (document as Document & ModelContextHost).modelContext
+      expect(second).toBe(first)
+      expect((second as Record<string, unknown>)[POLYFILL_MARKER]).toBe(true)
+
+      const deprecationWarnings = warnSpy.mock.calls.filter(([msg]) =>
+        typeof msg === 'string' && msg.includes('[WebMCPPolyfill] navigator.modelContext is deprecated')
+      )
+      expect(deprecationWarnings).toHaveLength(0)
+    } finally {
+      warnSpy.mockRestore()
+    }
   })
 
   it('复现：Chromium 把 modelContext 放在 Document.prototype —— 前置原型 getter 返回伪 native；步骤默认初始化；期望实例上是 polyfill 且不调用原生 getTools', async () => {
@@ -119,4 +129,37 @@ describe('initializeBuiltinWebMCP forcePolyfill', () => {
       }
     }
   })
+
+  it('复现：navigator.modelContext getter 存在时初始化不触发自身告警且正常挂载 polyfill —— 前置 navigator 挂有带警告的兼容 getter；步骤 initializeBuiltinWebMCP()；期望无 deprecation warning 且 document.modelContext 正确安装', () => {
+    const warnSpy = vi.spyOn(console, 'warn')
+    delete (Document.prototype as ModelContextHost).modelContext
+    delete (document as Document & ModelContextHost).modelContext
+
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        console.warn(
+          '[WebMCPPolyfill] navigator.modelContext is deprecated. The May 27, 2026 WebMCP draft moved the modelContext getter from Navigator to Document — use document.modelContext instead. See https://github.com/webmachinelearning/webmcp/pull/184.'
+        )
+        return { [POLYFILL_MARKER]: true }
+      }
+    })
+
+    try {
+      initializeBuiltinWebMCP()
+
+      const deprecationWarnings = warnSpy.mock.calls.filter(([msg]) =>
+        typeof msg === 'string' && msg.includes('[WebMCPPolyfill] navigator.modelContext is deprecated')
+      )
+      expect(deprecationWarnings).toHaveLength(0)
+
+      const docCtx = (document as Document & ModelContextHost).modelContext as Record<string, unknown>
+      expect(docCtx).toBeTruthy()
+      expect(docCtx[POLYFILL_MARKER]).toBe(true)
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
 })
+


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

- 修复 `initializeBuiltinWebMCP()` 在初始化或重复调用时误触发 `[WebMCPPolyfill] navigator.modelContext is deprecated...` 告警的问题。
- 增加强幂等检查：若 `document.modelContext` 已存在合法 JS polyfill 则直接跳过，避免重复安装。
- 在调用 `@mcp-b/webmcp-polyfill` 前中和/摘除 `navigator` 及其原型链上已存在的 `modelContext` getter，避免上游自检自踩雷，安装末尾由 polyfill 重新建立旧版兼容 alias。
- 补充中文「复现：」单测并通过 pr-gate 校验。

## What is the current behavior?

- 上游 `@mcp-b/webmcp-polyfill@5.1.0` 在兼容旧规范时，在 `navigator` 上定义了带警告提示的 `modelContext` getter。
- 在 `initializeWebMCPPolyfill()` 探测旧规范原生实现时，直接通过属性访问了 `nav.modelContext`。
- 若环境中已存在该 getter（如重复调用、微前端、或页面注入场景），该属性访问会触发自身 getter 并向控制台输出 `[WebMCPPolyfill] navigator.modelContext is deprecated...` 警告，且会导致其误以为存在旧规范原生实现而提前 return，跳过了后续完整的 JS context 安装流程。

## What is the new behavior?

- `initializeBuiltinWebMCP` 在执行前检查 `document.modelContext`，已安装 polyfill 时直接幂等退出。
- 在执行 polyfill 安装前通过 `neutralizeDeprecatedNavigatorModelContext` 摘除 `navigator` 及原型上的 `modelContext` getter，阻断自检自踩雷；polyfill 安装完成后会自动在最后一步重新建立标准的 `navigator.modelContext` 废弃兼容 alias。
- 初始化不再出现误报的控制台 deprecation warn，且正常挂载完整的 `StrictWebMCPContext`。

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- 复现测试：`packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * WebMCP now reliably uses the JavaScript polyfill by default, with an option to preserve an existing native context.
  * Repeated initialization safely reuses an existing polyfill without duplicate warnings.
* **Bug Fixes**
  * Improved compatibility with experimental browser implementations and deprecated context APIs.
  * Initialization failures now recover cleanly without leaving the browser context in a broken state.
  * Errors from unusual proxy-based contexts are handled safely instead of being exposed to applications.
* **Documentation**
  * Updated WebMCP requirements and design documentation to describe forced polyfill behavior and recovery scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->