### PR TITLE
fix(next-sdk): 规避 Chrome 146 原生 registerTool 在非 origin-keyed 文档抛 DOMException

### DIFF
--- a/docs/webmcp-sdk/global-tools.md
+++ b/docs/webmcp-sdk/global-tools.md
@@ -10,7 +10,11 @@
 
 在浏览器环境中初始化内置的 WebMCP 运行环境。该函数会注入 `document.modelContext` 的 JS Polyfill。
 
-Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先摘掉 `document`（含可配置原型）上的非 polyfill 实现，再安装 JS polyfill，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
+Chromium Origin Trial 阶段的原生 `modelContext.getTools()` / `registerTool()` 可能通过 Mojo IPC 触发渲染进程崩溃（`RESULT_CODE_KILLED_BAD_MESSAGE`）。上游 `@mcp-b/webmcp-polyfill`（本仓库当前 5.1.0）见 native 即跳过且不再提供 `forceOverride`。5.x 把 getter 装在 `Document.prototype`，SDK **默认 `forcePolyfill: true`**：先摘掉 `document` / `navigator`（含可配置原型）上的非 polyfill 实现，再安装 JS polyfill，避免走到会崩溃的原生 `getTools()`。仅在确认原生 WebMCP 可用时传入 `{ forcePolyfill: false }`。
+
+Chrome 146+ 在 `#enable-webmcp-testing` / Origin Trial 下会提供**不可配置**的原生 `Document.prototype.modelContext`。WebMCP 规范要求 origin-keyed agent cluster，否则原生 `registerTool()` reject 空消息 `SecurityError` **DOMException**（Windows 企业策略关闭 origin-keyed、或站点 `Origin-Agent-Cluster: ?0` / `document.domain` 时常见）。5.x 无法替换该原型 getter，且会把 `navigator.modelContext` native 接回 document。SDK 会同时中和 navigator native，并把 JS polyfill **挂到 document 实例**盖住 native；若仍读到 native，则跳过注册而不是调用原生 `registerTool`。
+
+JS polyfill 自身在 `window.originAgentCluster === false` 时也会把 `registerTool` 拒绝为无消息的 `SecurityError`。该检查面向原生跨文档隔离；页内 polyfill 注册表不需要它。SDK 在 polyfill 路径上会绕过该检查。
 
 请在页面入口尽早调用（`registerPageAgentTool()` 内部会调用本函数）。不要在初始化前把 `document.modelContext` 存进闭包，否则可能仍持有 native 引用。
 

--- a/packages/next-remoter/package.json
+++ b/packages/next-remoter/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-remoter",
-  "version": "0.4.9",
+  "version": "0.4.10",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/tiny-robot-remoter.html",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.9",
+  "version": "0.4.9-beta.1",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/package.json
+++ b/packages/next-sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opentiny/next-sdk",
-  "version": "0.4.9-beta.1",
+  "version": "0.4.10",
   "type": "module",
   "homepage": "https://docs.opentiny.design/next-sdk/guide/",
   "repository": {

--- a/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
+++ b/packages/next-sdk/page-tools/initialize-builtin-WebMCP.ts
@@ -28,6 +28,11 @@ function isWebMCPPolyfill(value: unknown): boolean {
   return Boolean(value && typeof value === 'object' && POLYFILL_MARKER in value && (value as Record<string, unknown>)[POLYFILL_MARKER])
 }
 
+/** 供同包 registerPageAgentTool 判断是否已挂上 JS polyfill，避免调用 Chrome 146+ 原生 registerTool */
+export function isBuiltinWebMCPPolyfill(value: unknown): boolean {
+  return isWebMCPPolyfill(value)
+}
+
 function readModelContext(target: ModelContextHost): unknown {
   try {
     return target.modelContext
@@ -69,33 +74,52 @@ function defineModelContext(target: object, value: unknown): boolean {
 }
 
 /**
- * 摘掉 document 上的 native：可配置的原型属性直接删除，让 5.x 自己安装 getter；
- * 实例上的 native 影子化为 undefined，避免 `if (doc.modelContext) return` 提前退出。
+ * 摘掉 host 上的 native `modelContext`：可配置的原型属性直接删除；
+ * 否则实例影子化为 undefined，避免 polyfill `if (doc.modelContext) return` 提前退出，
+ * 也避免 5.x 把 `navigator.modelContext` native 接回 document。
  */
-function neutralizeNativeDocumentModelContext(): void {
-  const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
-  if (!doc) return
-  if (isWebMCPPolyfill(readModelContext(doc))) return
+function neutralizeNativeModelContextHost(target: object, prototype: object | null): void {
+  const host = target as ModelContextHost
+  if (isWebMCPPolyfill(readModelContext(host))) return
 
-  const protoDesc = Object.getOwnPropertyDescriptor(Document.prototype, 'modelContext')
-  if (protoDesc?.configurable) {
-    const protoValue = readDescriptorValue(protoDesc, doc)
-    if (protoValue && !isWebMCPPolyfill(protoValue)) {
-      Reflect.deleteProperty(Document.prototype, 'modelContext')
+  if (prototype) {
+    const protoDesc = Object.getOwnPropertyDescriptor(prototype, 'modelContext')
+    if (protoDesc?.configurable) {
+      const protoValue = readDescriptorValue(protoDesc, target)
+      if (protoValue && !isWebMCPPolyfill(protoValue)) {
+        Reflect.deleteProperty(prototype, 'modelContext')
+      }
     }
   }
 
-  const current = readModelContext(doc)
+  const current = readModelContext(host)
   if (current && !isWebMCPPolyfill(current)) {
-    defineModelContext(doc, undefined)
+    defineModelContext(target, undefined)
   }
 }
 
+function neutralizeNativeDocumentModelContext(): void {
+  const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
+  if (!doc) return
+  neutralizeNativeModelContextHost(doc, Document.prototype)
+}
+
+function neutralizeNativeNavigatorModelContext(): void {
+  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
+  if (!nav) return
+  const proto = typeof Navigator !== 'undefined' ? Navigator.prototype : null
+  neutralizeNativeModelContextHost(nav, proto)
+}
+
 /**
- * 初始化后若实例上的 undefined 影子挡住了 polyfill 刚装上的原型 getter，则删掉影子。
- * 若原型 native 不可配置、删不掉，则继续影子化，避免走到 native getTools。
+ * 初始化后让 `document.modelContext` 读到 JS polyfill。
+ *
+ * Chrome 146+ WebIDL 把 native getter 放在 `Document.prototype` 且通常不可配置：
+ * 5.x 只会写入 WeakMap、不会替换原型 getter；删掉实例上的 undefined 影子后会重新暴露 native。
+ * 此时把 navigator 上已装好的 polyfill 挂到 document 实例，盖住 native。
+ * 挂不上则继续影子化 undefined，禁止走到会抛 DOMException / 杀进程的原生 registerTool。
  */
-function revealPolyfillOnDocument(): void {
+function attachPolyfillOntoDocument(): void {
   const doc = typeof document !== 'undefined' ? (document as Document & ModelContextHost) : null
   if (!doc) return
   if (isWebMCPPolyfill(readModelContext(doc))) return
@@ -110,10 +134,84 @@ function revealPolyfillOnDocument(): void {
 
   if (isWebMCPPolyfill(readModelContext(doc))) return
 
+  const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & ModelContextHost) : null
+  const navCtx = nav ? readModelContext(nav) : undefined
+  if (isWebMCPPolyfill(navCtx)) {
+    defineModelContext(doc, navCtx)
+    return
+  }
+
   const current = readModelContext(doc)
   if (current && !isWebMCPPolyfill(current)) {
     defineModelContext(doc, undefined)
   }
+}
+
+/**
+ * `@mcp-b/webmcp-polyfill` 在 `window.originAgentCluster === false` 时对 registerTool/getTools
+ * 抛出空消息 `SecurityError`。原生 WebMCP 需要 origin-keyed agent cluster；JS polyfill 只维护
+ * 页内注册表，不依赖该隔离。Windows 企业策略（OriginAgentClusterDefaultEnabled=false）、
+ * `Origin-Agent-Cluster: ?0` 或仍设置 `document.domain` 的站点会踩中，表现为
+ * `[next-sdk] page-agent-tool 注册失败: SecurityError`。
+ *
+ * 仅包装 polyfill 实例方法：调用期间影子化该属性，不改页面真实隔离，也不包装 native。
+ */
+const ORIGIN_AGENT_CLUSTER_BYPASS = '__nextSdkOriginAgentClusterBypass'
+
+type PolyfillToolContext = {
+  registerTool?: (...args: unknown[]) => unknown
+  getTools?: (...args: unknown[]) => unknown
+  executeTool?: (...args: unknown[]) => unknown
+}
+
+function withOriginAgentClusterBypass<T>(fn: () => T): T {
+  if (globalThis.originAgentCluster !== false) return fn()
+
+  const host = globalThis as typeof globalThis & { originAgentCluster?: boolean }
+  const previous = Object.getOwnPropertyDescriptor(host, 'originAgentCluster')
+  try {
+    Object.defineProperty(host, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => true
+    })
+  } catch {
+    return fn()
+  }
+
+  try {
+    return fn()
+  } finally {
+    try {
+      if (previous) Object.defineProperty(host, 'originAgentCluster', previous)
+      else Reflect.deleteProperty(host, 'originAgentCluster')
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+function wrapPolyfillToBypassOriginAgentCluster(ctx: unknown): void {
+  if (!ctx || typeof ctx !== 'object' || ORIGIN_AGENT_CLUSTER_BYPASS in ctx) return
+
+  const target = ctx as PolyfillToolContext & Record<string, unknown>
+  Object.defineProperty(target, ORIGIN_AGENT_CLUSTER_BYPASS, {
+    value: true,
+    enumerable: false,
+    configurable: true
+  })
+
+  for (const key of ['registerTool', 'getTools', 'executeTool'] as const) {
+    const original = target[key]
+    if (typeof original !== 'function') continue
+    const bound = original.bind(target)
+    target[key] = (...args: unknown[]) => withOriginAgentClusterBypass(() => bound(...args))
+  }
+}
+
+function wrapInstalledPolyfillIfPresent(): void {
+  const ctx = readModelContext(document as Document & ModelContextHost)
+  if (isWebMCPPolyfill(ctx)) wrapPolyfillToBypassOriginAgentCluster(ctx)
 }
 
 export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions) => {
@@ -124,18 +222,22 @@ export const initializeBuiltinWebMCP = (options?: InitializeBuiltinWebMCPOptions
   try {
     if (!forcePolyfill) {
       initializeWebMCPPolyfill()
+      wrapInstalledPolyfillIfPresent()
       return
     }
 
     neutralizeNativeDocumentModelContext()
+    neutralizeNativeNavigatorModelContext()
     initializeWebMCPPolyfill()
-    revealPolyfillOnDocument()
+    attachPolyfillOntoDocument()
 
     const ctx = readModelContext(document as Document & ModelContextHost)
     if (!isWebMCPPolyfill(ctx)) {
       console.warn(
-        '[next-sdk] 未能覆盖原生 document.modelContext，getTools/registerTool 可能触发 Chromium 渲染进程崩溃'
+        '[next-sdk] 未能覆盖原生 document.modelContext，getTools/registerTool 可能触发 Chromium 渲染进程崩溃或 DOMException'
       )
+    } else {
+      wrapPolyfillToBypassOriginAgentCluster(ctx)
     }
   } catch (err) {
     console.warn('[next-sdk] 自动注入 modelContext polyfill 失败:', err)

--- a/packages/next-sdk/page-tools/page-agent-tool.ts
+++ b/packages/next-sdk/page-tools/page-agent-tool.ts
@@ -1,4 +1,4 @@
-import { initializeBuiltinWebMCP } from './initialize-builtin-WebMCP'
+import { initializeBuiltinWebMCP, isBuiltinWebMCPPolyfill } from './initialize-builtin-WebMCP'
 import { zodToJsonSchema } from 'zod-to-json-schema'
 import pageAgentPrompt from './page-agent-prompt.md?raw'
 import { PageController } from '@page-agent/page-controller'
@@ -286,6 +286,14 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
     console.warn('[next-sdk] modelContext is not available, skipping page-agent-tool registration.')
     return createHandle()
   }
+  // Chrome 146+ 原生 registerTool 在非 origin-keyed 文档上 reject SecurityError DOMException；
+  // 强制 polyfill 后若仍读到 native，禁止调用，避免注册失败或杀渲染进程。
+  if (!isBuiltinWebMCPPolyfill(modelContext)) {
+    console.warn(
+      '[next-sdk] page-agent-tool 跳过原生 modelContext.registerTool（Chrome 146+ 可能抛出 DOMException）'
+    )
+    return createHandle()
+  }
   try {
     if ((window as any).__pageAgentToolAbortController) {
       ;(window as any).__pageAgentToolAbortController.abort()
@@ -320,7 +328,13 @@ export function registerPageAgentTool(options: PageAgentToolOptions = {}): PageA
       { signal: abortController.signal }
     )
   ).catch((err: unknown) => {
-    console.warn('[next-sdk] page-agent-tool 注册失败:', err)
+    const detail =
+      err instanceof DOMException
+        ? `${err.name}${err.message ? `: ${err.message}` : ''} (DOMException)`
+        : err instanceof Error
+          ? `${err.name}: ${err.message}`
+          : String(err)
+    console.warn('[next-sdk] page-agent-tool 注册失败:', detail, err)
   })
 
   setupPageAgentToolEventBridge(executePageAgentTool, pageController, actionContext)

--- a/packages/next-sdk/skills/page-agent/SKILL.md
+++ b/packages/next-sdk/skills/page-agent/SKILL.md
@@ -54,7 +54,7 @@ import {
 } from '@opentiny/next-sdk'
 ```
 
-- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`（默认 `forcePolyfill: true`，覆盖会崩溃的 Chromium 实验性 native）；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。
+- `registerPageAgentTool(options?)`：注册 `page-agent-tool`，内部调用 `initializeBuiltinWebMCP()`（默认 `forcePolyfill: true`，覆盖会崩溃的 Chromium 实验性 native）；重复调用为 **replace** 式重新初始化。返回 `{ showMask, hideMask }`。Chrome 146+ 原生 `registerTool` 在非 origin-keyed 文档上抛 `SecurityError` DOMException；SDK 会中和 `document`/`navigator` native 并把 JS polyfill 挂到 document 实例。polyfill 在 `originAgentCluster === false` 时也会抛空消息 `SecurityError`，仅对 polyfill 实例绕过该检查。
 - 运行期唯一配置面：`getPageAgentToolConfig` / `setPageAgentToolConfig`（`a11yConfig` 数组合并；`enableHighlight` / `cursorMode` 覆盖；支持 `mode: 'replace'`）。
 - `cursorMode`：`'actionOnly'`（默认，仅操作类出光标） / `'always'` / `'never'`。无参 `showMask()` 默认不出光标；操作类结束后若遮罩仍开着且 `cursorMode !== 'always'` 则收光标。`always` 下显式 `{ showCursor: false }` 仍可临时隐藏；`never` 覆盖显式 `showCursor: true`。
 - `whitelist` / `blacklist` 中的选择器字符串在构建无障碍树时 **动态解析**。

--- a/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
+++ b/packages/next-sdk/test/page-tools/initialize-builtin-WebMCP.test.ts
@@ -24,6 +24,15 @@ function installFakeNative(target: object, label: string) {
   return native
 }
 
+function restoreOriginAgentCluster(previous: PropertyDescriptor | undefined) {
+  try {
+    if (previous) Object.defineProperty(window, 'originAgentCluster', previous)
+    else delete (window as { originAgentCluster?: boolean }).originAgentCluster
+  } catch {
+    /* ignore */
+  }
+}
+
 afterEach(() => {
   // 清掉实例属性，避免用例互相污染；原型上若仍有 getter 则交回 polyfill / jsdom 默认
   try {
@@ -66,6 +75,25 @@ describe('initializeBuiltinWebMCP forcePolyfill', () => {
     const ctx = (document as Document & ModelContextHost).modelContext
     expect(ctx).toBe(native)
     expect((ctx as Record<string, unknown>)[POLYFILL_MARKER]).toBeUndefined()
+  })
+
+  it('复现：originAgentCluster 为 false 时不得误包装 native —— 前置伪 native 且 originAgentCluster === false；步骤 initializeBuiltinWebMCP({ forcePolyfill: false })；期望仍是原 native registerTool', () => {
+    const previous = Object.getOwnPropertyDescriptor(window, 'originAgentCluster')
+    Object.defineProperty(window, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => false
+    })
+    const native = installFakeNative(document, 'native-oac')
+
+    try {
+      initializeBuiltinWebMCP({ forcePolyfill: false })
+      const ctx = (document as Document & ModelContextHost).modelContext as { registerTool?: unknown }
+      expect(ctx).toBe(native)
+      expect(ctx.registerTool).toBe(native.registerTool)
+    } finally {
+      restoreOriginAgentCluster(previous)
+    }
   })
 
   it('已是 polyfill 时再次初始化仍保留 marker，不拆掉 JS context', () => {
@@ -116,6 +144,129 @@ describe('initializeBuiltinWebMCP forcePolyfill', () => {
         Object.defineProperty(Document.prototype, 'modelContext', previous)
       } else {
         delete (Document.prototype as ModelContextHost).modelContext
+      }
+    }
+  })
+
+  it('复现：Windows originAgentCluster 为 false 时 registerTool 抛 SecurityError —— 前置 window.originAgentCluster === false（企业策略 OriginAgentClusterDefaultEnabled=false / Origin-Agent-Cluster:?0）；步骤 initializeBuiltinWebMCP 后 registerTool+getTools；期望不抛 SecurityError 且工具可被发现', async () => {
+    const previous = Object.getOwnPropertyDescriptor(window, 'originAgentCluster')
+    Object.defineProperty(window, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => false
+    })
+
+    try {
+      initializeBuiltinWebMCP()
+
+      const ctx = (document as Document & ModelContextHost).modelContext as {
+        [key: string]: unknown
+        registerTool: (tool: Record<string, unknown>) => Promise<unknown>
+        getTools: () => Promise<Array<{ name: string }>>
+      }
+      expect(ctx[POLYFILL_MARKER]).toBe(true)
+
+      const toolName = `probe-origin-agent-cluster-${Date.now()}`
+      await expect(
+        ctx.registerTool({
+          name: toolName,
+          description: 'probe originAgentCluster bypass',
+          inputSchema: { type: 'object', properties: {} },
+          execute: async () => ({ ok: true })
+        })
+      ).resolves.toBeUndefined()
+
+      const tools = await ctx.getTools()
+      expect(tools.some((tool) => tool.name === toolName)).toBe(true)
+    } finally {
+      restoreOriginAgentCluster(previous)
+    }
+  })
+
+  it('复现：Chrome 146 不可删除的原型 native + originAgentCluster false 时注册抛 DOMException —— 前置 Document.prototype.modelContext 为删不掉的 native，且 navigator.modelContext 同为 native，window.originAgentCluster === false；步骤 initializeBuiltinWebMCP；期望 document.modelContext 为 JS polyfill，registerTool 成功且不调用原生', async () => {
+    const native = {
+      getTools: vi.fn(async () => {
+        throw new Error('native getTools should not be called')
+      }),
+      registerTool: vi.fn(async () => {
+        throw new DOMException('', 'SecurityError')
+      }),
+      executeTool: vi.fn()
+    }
+    const previousDoc = Object.getOwnPropertyDescriptor(Document.prototype, 'modelContext')
+    const previousNav = Object.getOwnPropertyDescriptor(navigator, 'modelContext')
+    const previousOac = Object.getOwnPropertyDescriptor(window, 'originAgentCluster')
+
+    Object.defineProperty(Document.prototype, 'modelContext', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return native
+      }
+    })
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      writable: true,
+      enumerable: true,
+      value: native
+    })
+    Object.defineProperty(window, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => false
+    })
+
+    const origDelete = Reflect.deleteProperty.bind(Reflect)
+    const deleteSpy = vi.spyOn(Reflect, 'deleteProperty').mockImplementation((target, key) => {
+      if (target === Document.prototype && key === 'modelContext') return false
+      return origDelete(target, key)
+    })
+
+    try {
+      try {
+        delete (document as Document & ModelContextHost).modelContext
+      } catch {
+        /* ignore */
+      }
+
+      initializeBuiltinWebMCP()
+
+      const ctx = (document as Document & ModelContextHost).modelContext as {
+        [key: string]: unknown
+        registerTool: (tool: Record<string, unknown>) => Promise<unknown>
+        getTools: () => Promise<Array<{ name: string }>>
+      }
+      expect(ctx).toBeTruthy()
+      expect(ctx[POLYFILL_MARKER]).toBe(true)
+      expect(ctx).not.toBe(native)
+
+      const toolName = `probe-chrome146-${Date.now()}`
+      await expect(
+        ctx.registerTool({
+          name: toolName,
+          description: 'probe chrome 146 native override',
+          inputSchema: { type: 'object', properties: {} },
+          execute: async () => ({ ok: true })
+        })
+      ).resolves.toBeUndefined()
+
+      const tools = await ctx.getTools()
+      expect(tools.some((tool) => tool.name === toolName)).toBe(true)
+      expect(native.registerTool).not.toHaveBeenCalled()
+      expect(native.getTools).not.toHaveBeenCalled()
+    } finally {
+      deleteSpy.mockRestore()
+      restoreOriginAgentCluster(previousOac)
+      try {
+        if (previousNav) Object.defineProperty(navigator, 'modelContext', previousNav)
+        else delete (navigator as Navigator & ModelContextHost).modelContext
+      } catch {
+        /* ignore */
+      }
+      if (previousDoc) {
+        Object.defineProperty(Document.prototype, 'modelContext', previousDoc)
+      } else {
+        origDelete(Document.prototype, 'modelContext')
       }
     }
   })

--- a/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
+++ b/packages/next-sdk/test/page-tools/page-agent-tool.test.ts
@@ -252,4 +252,108 @@ describe('registerPageAgentTool - 工具注册与注销机制', () => {
     
     ;(document as any).modelContext.registerTool = originalRegister;
   })
+
+  it('复现：Windows 加载 page-agent-tool 失败 SecurityError —— 前置 window.originAgentCluster === false；步骤 registerPageAgentTool；期望不 warn 注册失败且 getTools 含 page-agent-tool', async () => {
+    const previous = Object.getOwnPropertyDescriptor(window, 'originAgentCluster')
+    Object.defineProperty(window, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => false
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      registerPageAgentTool()
+      await vi.waitFor(async () => {
+        const tools = await (document as any).modelContext.getTools()
+        expect(tools.filter((t: { name: string }) => t.name === 'page-agent-tool').length).toBe(1)
+      })
+      expect(
+        warn.mock.calls.some((call) => String(call[0]).includes('page-agent-tool 注册失败'))
+      ).toBe(false)
+    } finally {
+      warn.mockRestore()
+      try {
+        if (previous) Object.defineProperty(window, 'originAgentCluster', previous)
+        else delete (window as { originAgentCluster?: boolean }).originAgentCluster
+      } catch {
+        /* ignore */
+      }
+    }
+  })
+
+  it('复现：Chrome 146 Windows 最新版注册失败 DOMException —— 前置不可删除的原生 Document.prototype.modelContext、navigator.modelContext 同为 native、originAgentCluster === false；步骤 registerPageAgentTool；期望走 JS polyfill 注册成功且不调用原生 registerTool', async () => {
+    const native = {
+      getTools: vi.fn(async () => []),
+      registerTool: vi.fn(async () => {
+        throw new DOMException('', 'SecurityError')
+      }),
+      executeTool: vi.fn()
+    }
+    const previousDoc = Object.getOwnPropertyDescriptor(Document.prototype, 'modelContext')
+    const previousNav = Object.getOwnPropertyDescriptor(navigator, 'modelContext')
+    const previousOac = Object.getOwnPropertyDescriptor(window, 'originAgentCluster')
+    Object.defineProperty(Document.prototype, 'modelContext', {
+      configurable: true,
+      enumerable: true,
+      get() {
+        return native
+      }
+    })
+    Object.defineProperty(navigator, 'modelContext', {
+      configurable: true,
+      writable: true,
+      enumerable: true,
+      value: native
+    })
+    Object.defineProperty(window, 'originAgentCluster', {
+      configurable: true,
+      enumerable: true,
+      get: () => false
+    })
+    const origDelete = Reflect.deleteProperty.bind(Reflect)
+    const deleteSpy = vi.spyOn(Reflect, 'deleteProperty').mockImplementation((target, key) => {
+      if (target === Document.prototype && key === 'modelContext') return false
+      return origDelete(target, key)
+    })
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      try {
+        delete (document as { modelContext?: unknown }).modelContext
+      } catch {
+        /* ignore */
+      }
+
+      registerPageAgentTool()
+      await vi.waitFor(async () => {
+        const tools = await (document as any).modelContext.getTools()
+        expect(tools.filter((t: { name: string }) => t.name === 'page-agent-tool').length).toBe(1)
+      })
+      expect(native.registerTool).not.toHaveBeenCalled()
+      expect(
+        warn.mock.calls.some((call) => String(call[0]).includes('page-agent-tool 注册失败'))
+      ).toBe(false)
+    } finally {
+      warn.mockRestore()
+      deleteSpy.mockRestore()
+      try {
+        if (previousOac) Object.defineProperty(window, 'originAgentCluster', previousOac)
+        else delete (window as { originAgentCluster?: boolean }).originAgentCluster
+      } catch {
+        /* ignore */
+      }
+      try {
+        if (previousNav) Object.defineProperty(navigator, 'modelContext', previousNav)
+        else delete (navigator as { modelContext?: unknown }).modelContext
+      } catch {
+        /* ignore */
+      }
+      if (previousDoc) {
+        Object.defineProperty(Document.prototype, 'modelContext', previousDoc)
+      } else {
+        origDelete(Document.prototype, 'modelContext')
+      }
+    }
+  })
 })


### PR DESCRIPTION
# Pull Request (OpenTiny NEXT-SDKs)

> PR Gate 根据**约定式标题**判断类型（`fix` / `feat` / `docs` / …），并从本 PR **变更文件**自动校验：Bug 须有复现测试，Feature 须同时有 Spec 与测试。
> 标签为兜底（与 auto-label 一致：`bug` / `enhancement` 等）。琐碎 Feature 可打 `skip-spec`（仅豁免 Spec）；应急打 `gate-bypass`。

## Summary

-

## What is the current behavior?

-

## What is the new behavior?

-

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## Other information

（可选。Issue 请用 GitHub 原生关联，无需手填路径。）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebMCP initialization on Chrome 146+ and environments without origin-keyed agent clusters.
  * Prevented unsupported native tool registration failures by using the compatible polyfill path.
  * Improved page-agent tool registration and error reporting in affected browser configurations.

* **Documentation**
  * Updated WebMCP and page-agent guidance with browser compatibility details and polyfill behavior.

* **Chores**
  * Published the Next SDK and Next Remoter as version 0.4.10.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->